### PR TITLE
Removing global state from world, allowing creating multiple world in…

### DIFF
--- a/lib/core/src/display/render/passes/screen.rs
+++ b/lib/core/src/display/render/passes/screen.rs
@@ -4,6 +4,7 @@ use crate::prelude::*;
 
 use crate::display::render::pipeline::*;
 use crate::display::symbol::Screen;
+use crate::display::world::World;
 use crate::system::gpu::*;
 
 
@@ -13,15 +14,16 @@ use crate::system::gpu::*;
 // ========================
 
 /// Renders the last `'color'` variable to the screen.
-#[derive(Clone,Debug,Default)]
+#[derive(Clone,Debug)]
 pub struct ScreenRenderPass {
     screen: Screen,
 }
 
 impl ScreenRenderPass {
     /// Constructor.
-    pub fn new() -> Self {
-        default()
+    pub fn new(world:&World) -> Self {
+        let screen = Screen::new(world);
+        Self {screen}
     }
 }
 

--- a/lib/core/src/display/shape/primitive/system.rs
+++ b/lib/core/src/display/shape/primitive/system.rs
@@ -8,6 +8,7 @@ use crate::display::symbol::material::Material;
 use crate::display::shape::primitive::shader;
 use crate::display::shape::primitive::def::class::Shape;
 use crate::display::object::*;
+use crate::display::world::World;
 use crate::system::gpu::types::*;
 
 
@@ -21,8 +22,8 @@ pub struct ShapeSystem {
 
 impl ShapeSystem {
     /// Constructor.
-    pub fn new<S:Shape>(shape:&S) -> Self {
-        let sprite_system = SpriteSystem::new();
+    pub fn new<S:Shape>(world:&World, shape:&S) -> Self {
+        let sprite_system = SpriteSystem::new(world);
         sprite_system.set_material(Self::surface_material(shape));
         Self {sprite_system}
     }

--- a/lib/core/src/display/symbol/geometry/compound/screen.rs
+++ b/lib/core/src/display/symbol/geometry/compound/screen.rs
@@ -8,6 +8,7 @@ use crate::prelude::*;
 use crate::display::symbol::geometry::Sprite;
 use crate::display::symbol::geometry::SpriteSystem;
 use crate::display::symbol::material::Material;
+use crate::display::world::World;
 use crate::system::gpu::data::texture;
 use crate::system::gpu::data::types::*;
 
@@ -22,20 +23,14 @@ pub struct Screen {
 
 impl CloneRef for Screen {}
 
-impl Default for Screen {
-    fn default() -> Self {
-        let sprite_system = SpriteSystem::new();
+impl Screen {
+    /// Constructor.
+    pub fn new(world:&World) -> Self {
+        let sprite_system = SpriteSystem::new(world);
         sprite_system.set_geometry_material(Self::geometry_material());
         sprite_system.set_material(Self::surface_material());
         let sprite = sprite_system.new_instance();
         Self {sprite_system,sprite}
-    }
-}
-
-impl Screen {
-    /// Constructor.
-    pub fn new() -> Self {
-        default()
     }
 
     /// Local variables used by the screen object.

--- a/lib/core/src/display/symbol/geometry/compound/sprite.rs
+++ b/lib/core/src/display/symbol/geometry/compound/sprite.rs
@@ -8,7 +8,7 @@ use crate::debug::Stats;
 use crate::display::object::*;
 use crate::display::symbol::material::Material;
 use crate::display::symbol::Symbol;
-use crate::display::world;
+use crate::display::world::World;
 use crate::system::gpu::types::*;
 
 
@@ -104,8 +104,8 @@ pub struct SpriteSystemData {
 
 impl {
     /// Constructor.
-    pub fn new() -> Self {
-        let scene          = world::get_scene();
+    pub fn new(world:&World) -> Self {
+        let scene          = world.scene();
         let stats          = scene.stats();
         let symbol         = scene.new_symbol();
         let mesh           = symbol.surface();

--- a/lib/core/src/display/world.rs
+++ b/lib/core/src/display/world.rs
@@ -33,39 +33,6 @@ pub use stats::*;
 
 
 
-// ===========================
-// === UNSAFE GLOBAL STATE ===
-// ===========================
-
-/// The following code is very unsafe and should disappear in the future. We are using it in order
-/// to keep the API simple and future-proof. Each `Stage` is associated with HTML Canvas element,
-/// and we currently support a single stage only. Although this is very low-priority task, as we
-/// would not need it in our use case, it would be nice to have support for it in the library.
-/// Supporting multiple stages means, that we would be able to create a symbol, add it to a scene,
-/// and then add it to another scene (while disconnecting the previous one). This would require
-/// symbol to be associated with different contexts / different buffers depending on the root
-/// parent object. Currently this information is hardcoded while object creation and it is obtained
-/// from these global variables. By using them we simulate the final API, where symbols do not need
-/// to know scene in order to be constructed.
-
-static mut SCENE: Option<Scene> = None;
-
-/// Very unsafe function. Do not use. See documentation of `WORLD` to learn more.
-pub(crate) fn get_scene() -> Scene {
-    unsafe {
-        SCENE.as_ref().unwrap_or_else(|| panic!("World not initialized.")).clone_ref()
-    }
-}
-
-/// Very unsafe function. Do not use. See documentation of `WORLD` to learn more.
-fn init_global_variables(world:&World) {
-    unsafe {
-        SCENE = Some(world.rc.borrow().scene.clone_ref());
-    }
-}
-
-
-
 // =================
 // === WorldData ===
 // =================
@@ -226,7 +193,7 @@ impl World {
     pub fn new(world_data: WorldData) -> Self {
         let rc = Rc::new(RefCell::new(world_data));
         let out = Self {rc};
-        init_global_variables(&out);
+//        init_global_variables(&out);
         out.init_composer();
         out
     }
@@ -286,7 +253,7 @@ impl World {
         // pixel_read_pass.set_threshold(1);
         let pipeline = RenderPipeline::new()
             .add(DisplayObjectRenderPass::new(root))
-            .add(ScreenRenderPass::new())
+            .add(ScreenRenderPass::new(self))
             .add(pixel_read_pass);
         self.rc.borrow_mut().scene.set_render_pipeline(pipeline);
     }

--- a/lib/core/src/examples/shapes.rs
+++ b/lib/core/src/examples/shapes.rs
@@ -39,7 +39,7 @@ fn init(world: &World) {
     let s2 = s1.translate(25.0,0.0);
     let s3 = &s1 + &s2;
 
-    let shape_system = ShapeSystem::new(&s3);
+    let shape_system = ShapeSystem::new(world, &s3);
     let sprite = shape_system.new_instance();
     sprite.size().set(Vector2::new(200.0,200.0));
     sprite.mod_position(|t| {

--- a/lib/core/src/examples/sprite_system.rs
+++ b/lib/core/src/examples/sprite_system.rs
@@ -28,7 +28,7 @@ fn init(world: &World) {
     let scene         = world.scene();
     let camera        = scene.camera()  ;
     let navigator     = Navigator::new(&scene, &camera).expect("Couldn't create navigator");
-    let sprite_system = SpriteSystem::new();
+    let sprite_system = SpriteSystem::new(world);
     let sprite1       = sprite_system.new_instance();
     sprite1.size().set(Vector2::new(10.0, 10.0));
     sprite1.mod_position(|t| *t = Vector3::new(5.0, 5.0, 0.0));


### PR DESCRIPTION
### Pull Request Description
- Removes a bad design we did in the past.

### Important Notes
- Now creation of all symbols requires a `&World` argument, which is ugly but necessary.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

