### PR TITLE
Moving cursors after each edit

### DIFF
--- a/lib/core/src/display/shape/text/text_field/location.rs
+++ b/lib/core/src/display/shape/text/text_field/location.rs
@@ -1,0 +1,173 @@
+//! Module with content regarding location in text (e.g. location of cursors or changes etc.)
+
+use crate::display::shape::text::text_field::content::TextChange;
+
+use std::ops::Range;
+
+// ====================
+// === TextLocation ===
+// ====================
+
+/// A position of character in a multiline text.
+#[derive(Copy,Clone,Debug,PartialEq,Eq,PartialOrd,Ord)]
+pub struct TextLocation {
+    /// Line index.
+    pub line: usize,
+    /// Column is a index of char in given line.
+    pub column: usize,
+}
+
+impl TextLocation {
+    /// Create location at begin of given line.
+    pub fn at_line_begin(line_index:usize) -> TextLocation {
+        TextLocation {
+            line   : line_index,
+            column : 0,
+        }
+    }
+
+    /// Create location at begin of the whole document.
+    pub fn at_document_begin() -> TextLocation {
+        TextLocation {
+            line   : 0,
+            column : 0,
+        }
+    }
+}
+
+
+
+// ==========================
+// === TextLocationChange ===
+// ==========================
+
+/// A locations change after some edit.
+///
+/// After on or many changes to text content, the following locations are altered (e.g. when you
+/// remove one line, all the next location are shifted one line up). This structure keeps history
+/// of sequence of text changes and can tell how the further TextLocations should change to mark
+/// the same place in the text.
+#[derive(Copy,Clone,Debug,Default)]
+pub struct TextLocationChange {
+    /// A current line offset for all next locations;
+    pub line_offset : isize,
+    /// Last line altered by considered text changes (in the current numeration).
+    pub last_changed_line : usize,
+    /// The column offset for all next locations in `last_changed_line`.
+    pub column_offset : isize,
+}
+
+impl TextLocationChange {
+    /// Return the new location after considering text changes so far.
+    pub fn apply_to(&self, location:TextLocation) -> TextLocation {
+        let line   = (location.line as isize + self.line_offset) as usize;
+        let column = if line == self.last_changed_line {
+            (location.column as isize + self.column_offset) as usize
+        } else {
+            location.column
+        };
+        TextLocation{line,column}
+    }
+
+    /// Return the new location range after considering text changes so far.
+    pub fn apply_to_range(&self, range:Range<TextLocation>) -> Range<TextLocation> {
+        self.apply_to(range.start)..self.apply_to(range.end)
+    }
+
+    /// Add a new text change into consideration.
+    pub fn add_change(&mut self, change:&TextChange) {
+        let removed             = &change.replaced;
+        let inserted            = change.inserted_text_range();
+        let lines_removed       = (removed.end.line - removed.start.line) as isize;
+        let lines_added         = (inserted.end.line - inserted.start.line) as isize;
+        let new_line_offset     = self.line_offset + lines_added - lines_removed;
+        let change_in_last_line = removed.start.line != self.last_changed_line;
+        let drop_column_offset  = !change_in_last_line || lines_removed > 0;
+        if  drop_column_offset {
+            self.column_offset = 0;
+        }
+        self.column_offset += inserted.end.column as isize - removed.end.column as isize;
+        self.last_changed_line = inserted.end.line;
+    }
+}
+
+
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn applying_change_to_location() {
+        // positive offsets
+        let change = TextLocationChange {
+            line_offset: 1,
+            last_changed_line: 5,
+            column_offset: 3
+        };
+        let in_last_changed_line     = TextLocation{line:4, column:2};
+        let not_in_last_changed_line = TextLocation{line:5, column:2};
+        assert_eq!(TextLocation{line:5, column:5}, change.apply_to(in_last_changed_line));
+        assert_eq!(TextLocation{line:6, column:2}, change.apply_to(not_in_last_changed_line));
+
+        // negative offsets
+        let change = TextLocationChange {
+            line_offset: -1,
+            last_changed_line: 5,
+            column_offset: -2
+        };
+        let in_last_changed_line     = TextLocation{line:6, column:2};
+        let not_in_last_changed_line = TextLocation{line:5, column:2};
+        assert_eq!(TextLocation{line:5, column:0}, change.apply_to(in_last_changed_line));
+        assert_eq!(TextLocation{line:4, column:2}, change.apply_to(not_in_last_changed_line));
+    }
+
+    #[test]
+    fn adding_changes() {
+        let one_line  = "One line";
+        let two_lines = "Two\nLines";
+        let mut location_change = TextLocationChange::default();
+
+        // initial change
+        let replaced = TextLocation{line:2, column:2}..TextLocation{line:2, column: 2};
+        location_change.add_change(&TextChange::replace(replaced,one_line));
+        assert_eq!(0, location_change.line_offset);
+        assert_eq!(2, location_change.last_changed_line);
+        assert_eq!(8, location_change.column_offset);
+
+        // single line in the same line as previous
+        let replaced = TextLocation{line:2, column:2}..TextLocation{line:2, column: 13};
+        location_change.add_change(&TextChange::replace(replaced,one_line));
+        assert_eq!(0, location_change.line_offset);
+        assert_eq!(2, location_change.last_changed_line);
+        assert_eq!(5, location_change.column_offset);
+
+        // single -> multiple lines in the same line as previous
+        let replaced = TextLocation{line:2, column:2}..TextLocation{line:2, column: 8};
+        location_change.add_change(&TextChange::replace(replaced,two_lines));
+        assert_eq!(1, location_change.line_offset);
+        assert_eq!(3, location_change.last_changed_line);
+        assert_eq!(2, location_change.column_offset);
+
+        // multiple -> multiple lines
+        let replaced = TextLocation{line:3, column:2}..TextLocation{line:7, column: 3};
+        location_change.add_change(&TextChange::replace(replaced,two_lines));
+        assert_eq!(-2, location_change.line_offset);
+        assert_eq!(4 , location_change.last_changed_line);
+        assert_eq!(2 , location_change.column_offset);
+
+        // multiple -> single lines in the same line as previous
+        let replaced = TextLocation{line:4, column:2}..TextLocation{line:5, column: 11};
+        location_change.add_change(&TextChange::replace(replaced,one_line));
+        assert_eq!(-3, location_change.line_offset);
+        assert_eq!(4 , location_change.last_changed_line);
+        assert_eq!(-1, location_change.column_offset);
+
+        // single line in other line than previous
+        let replaced = TextLocation{line:5, column:2}..TextLocation{line:5, column: 12};
+        location_change.add_change(&TextChange::replace(replaced,one_line));
+        assert_eq!(-3, location_change.line_offset);
+        assert_eq!(5 , location_change.last_changed_line);
+        assert_eq!(-2, location_change.column_offset);
+    }
+}

--- a/lib/core/src/display/shape/text/text_field/location.rs
+++ b/lib/core/src/display/shape/text/text_field/location.rs
@@ -80,13 +80,13 @@ impl TextLocationChange {
         let inserted            = change.inserted_text_range();
         let lines_removed       = (removed.end.line - removed.start.line) as isize;
         let lines_added         = (inserted.end.line - inserted.start.line) as isize;
-        let new_line_offset     = self.line_offset + lines_added - lines_removed;
-        let change_in_last_line = removed.start.line != self.last_changed_line;
+        let change_in_last_line = removed.start.line == self.last_changed_line;
         let drop_column_offset  = !change_in_last_line || lines_removed > 0;
-        if  drop_column_offset {
+        if drop_column_offset {
             self.column_offset = 0;
         }
-        self.column_offset += inserted.end.column as isize - removed.end.column as isize;
+        self.line_offset      += lines_added - lines_removed;
+        self.column_offset    += inserted.end.column as isize - removed.end.column as isize;
         self.last_changed_line = inserted.end.line;
     }
 }

--- a/lib/core/src/display/shape/text/text_field/render/selection.rs
+++ b/lib/core/src/display/shape/text/text_field/render/selection.rs
@@ -2,8 +2,8 @@
 
 use crate::display::shape::primitive::system::ShapeSystem;
 use crate::display::shape::text::text_field::content::TextFieldContentFullInfo;
-use crate::display::shape::text::text_field::content::TextLocation;
 use crate::display::shape::text::text_field::cursor::Cursor;
+use crate::display::shape::text::text_field::location::TextLocation;
 use crate::display::symbol::geometry::compound::sprite::Sprite;
 
 use nalgebra::Vector2;

--- a/lib/core/src/examples/text_selecting.rs
+++ b/lib/core/src/examples/text_selecting.rs
@@ -21,6 +21,7 @@ use web_sys::MouseEvent;
 use failure::_core::cell::RefCell;
 use wasm_bindgen::prelude::*;
 use crate::system::web::text_input::KeyboardBinding;
+use crate::display::shape::text::text_field::location::TextLocation;
 
 
 const TEXT:&str =
@@ -58,6 +59,7 @@ pub fn run_example_text_selecting() {
         let text_field = TextField::new(&world,TEXT,properties,&mut fonts);
         text_field.set_position(Vector3::new(10.0, 600.0, 0.0));
         text_field.jump_cursor(Vector2::new(50.0, -40.0),false,&mut fonts);
+        text_field.add_cursor(TextLocation{line:1, column:0}, &mut fonts);
         world.add_child(&text_field);
         text_field.update();
 


### PR DESCRIPTION
### Pull Request Description
Before, all edits did not adjust the cursor positions, but they remained with their selection in the same location. This PR changes that.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

