### PR TITLE
Added webdriver to pass parameters to chromedriver

### DIFF
--- a/lib/core/webdriver.json
+++ b/lib/core/webdriver.json
@@ -1,0 +1,8 @@
+{
+  "goog:chromeOptions": {
+    "args": [
+      "--no-proxy-server",
+      "--no-sandbox"
+    ]
+  }
+}


### PR DESCRIPTION
### Pull Request Description
This PR attempts to fix headless chrome renderer timeouts.

### Important Notes
- It adds a webdriver config file passing --no-sandbox parameter to chromedriver as indicated in https://github.com/theintern/intern/issues/878

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

