### PR TITLE
JSON-RPC uses `params`, not `input`

### DIFF
--- a/lib/ide/file-manager/README.md
+++ b/lib/ide/file-manager/README.md
@@ -96,7 +96,7 @@ format, e.g. `"2020-01-07T21:25:26Z"`.
     "jsonrpc" : "2.0",
     "id"      : 0,
     "method"  : "exists",
-    "input"   : { "path" : "./Main.luna" }
+    "params"  : { "path" : "./Main.luna" }
 }
 ```
 #### Response

--- a/lib/ide/file-manager/src/lib.rs
+++ b/lib/ide/file-manager/src/lib.rs
@@ -312,7 +312,7 @@ mod tests {
 
         let request = transport.expect_message::<RequestMessage<Value>>();
         assert_eq!(request.method, expected_method);
-        assert_eq!(request.input,  expected_input);
+        assert_eq!(request.params, expected_input);
 
         let response = Message::new_success(request.id, result);
         transport.mock_peer_message(response);

--- a/lib/ide/json-rpc/src/messages.rs
+++ b/lib/ide/json-rpc/src/messages.rs
@@ -28,6 +28,7 @@ pub struct Message<T> {
     pub payload: T
 }
 
+
 // === Common Message Subtypes ===
 
 /// A request message.
@@ -38,6 +39,7 @@ pub type ResponseMessage<Ret> = Message<Response<Ret>>;
 
 /// A response message.
 pub type NotificationMessage<Ret> = Message<Notification<MethodCall<Ret>>>;
+
 
 // === `new` Functions ===
 
@@ -52,8 +54,8 @@ impl<T> Message<T> {
 
     /// Construct a request message.
     pub fn new_request
-    (id:Id, method:&str, input:T) -> RequestMessage<T> {
-        let call = MethodCall {method: method.into(),input};
+    (id:Id, method:&str, params:T) -> RequestMessage<T> {
+        let call = MethodCall {method: method.into(),params};
         let request = Request::new(id,call);
         Message::new(request)
     }
@@ -76,8 +78,8 @@ impl<T> Message<T> {
 
     /// Construct a request message.
     pub fn new_notification
-    (method:&'static str, input:T) -> NotificationMessage<T> {
-        let call = MethodCall {method: method.into(),input};
+    (method:&'static str, params:T) -> NotificationMessage<T> {
+        let call = MethodCall {method: method.into(),params};
         let notification = Notification(call);
         Message::new(notification)
     }
@@ -90,7 +92,7 @@ impl<T> Message<T> {
 // ========================
 
 /// An id identifying the call request.
-/// 
+///
 /// Each request made by client should get a unique id (unique in a context of
 /// the current session). Auto-incrementing integer is a common choice.
 #[derive(Serialize, Deserialize)]
@@ -218,9 +220,9 @@ pub fn decode_incoming_message
 }
 
 /// Message from server to client.
-/// 
-/// `In` is any serializable (or already serialized) representation of the 
-/// method arguments passed in this call. 
+///
+/// `In` is any serializable (or already serialized) representation of the
+/// method arguments passed in this call.
 #[derive(Serialize, Deserialize, Debug, PartialEq)]
 #[derive(Shrinkwrap)]
 pub struct MethodCall<In> {
@@ -228,7 +230,7 @@ pub struct MethodCall<In> {
     pub method : String,
     /// Method arguments.
     #[shrinkwrap(main_field)]
-    pub input  : In
+    pub params : In
 }
 
 
@@ -256,7 +258,7 @@ mod tests {
         // === Field Names ===
         pub const JSONRPC : &str = "jsonrpc";
         pub const METHOD  : &str = "method";
-        pub const INPUT   : &str = "input";
+        pub const PARAMS  : &str = "params";
         pub const ID      : &str = "id";
 
         // === Version strings ===
@@ -279,11 +281,11 @@ mod tests {
         let id = Id(50);
         let method  = "mockMethod";
         let number  = 124;
-        let input   = MockRequest {number};
-        let call    = MethodCall {method:method.into(),input};
+        let params  = MockRequest {number};
+        let call    = MethodCall {method:method.into(),params};
         let request = Request::new(id,call);
         let message = Message::new(request);
-        
+
         let json = serde_json::to_value(message).expect("serialization error");
         let json = json.as_object().expect("expected an object");
         assert_eq!(json.len(), protocol::FIELD_COUNT_IN_REQUEST);
@@ -291,18 +293,18 @@ mod tests {
         assert_eq!(jsonrpc_field, protocol::VERSION2_STRING);
         assert_eq!(expect_field(json, protocol::ID), id.0);
         assert_eq!(expect_field(json, protocol::METHOD), method);
-        let input_json = expect_field(json, protocol::INPUT);
-        let input_json = input_json.as_object().expect("input must be object");
-        assert_eq!(input_json.len(), MockRequest::FIELD_COUNT);
-        assert_eq!(expect_field(input_json, MockRequest::FIELD_NAME), number);
+        let params_json = expect_field(json, protocol::PARAMS);
+        let params_json = params_json.as_object().expect("params must be object");
+        assert_eq!(params_json.len(), MockRequest::FIELD_COUNT);
+        assert_eq!(expect_field(params_json, MockRequest::FIELD_NAME), number);
     }
 
     #[test]
     fn test_notification_serialization() {
         let method       = "mockNotification";
         let number       = 125;
-        let input        = MockRequest {number};
-        let call         = MethodCall {method:method.into(),input};
+        let params       = MockRequest {number};
+        let call         = MethodCall {method:method.into(),params};
         let notification = Notification(call);
         let message      = Message::new(notification);
 
@@ -314,10 +316,10 @@ mod tests {
         let jsonrpc_field = expect_field(json, protocol::JSONRPC);
         assert_eq!(jsonrpc_field, protocol::VERSION2_STRING);
         assert_eq!(expect_field(json, protocol::METHOD), method);
-        let input_json = expect_field(json, protocol::INPUT);
-        let input_json = input_json.as_object().expect("input must be object");
-        assert_eq!(input_json.len(), MockRequest::FIELD_COUNT);
-        assert_eq!(expect_field(input_json, MockRequest::FIELD_NAME), number);
+        let params_json = expect_field(json, protocol::PARAMS);
+        let params_json = input_json.as_object().expect("params must be object");
+        assert_eq!(params_json.len(), MockRequest::FIELD_COUNT);
+        assert_eq!(expect_field(params_json, MockRequest::FIELD_NAME), number);
     }
 
 

--- a/lib/ide/json-rpc/src/messages.rs
+++ b/lib/ide/json-rpc/src/messages.rs
@@ -317,7 +317,7 @@ mod tests {
         assert_eq!(jsonrpc_field, protocol::VERSION2_STRING);
         assert_eq!(expect_field(json, protocol::METHOD), method);
         let params_json = expect_field(json, protocol::PARAMS);
-        let params_json = input_json.as_object().expect("params must be object");
+        let params_json = params_json.as_object().expect("params must be object");
         assert_eq!(params_json.len(), MockRequest::FIELD_COUNT);
         assert_eq!(expect_field(params_json, MockRequest::FIELD_NAME), number);
     }


### PR DESCRIPTION
### Pull Request Description
For some reason when implementing JSON-RPC I used `input` instead of `params` (as specified).
This PR fixes this.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

