### PR TITLE
Fixes and Improvements for File Manager Mock Server

### DIFF
--- a/lib/ide/file-manager/mock-server/Cargo.toml
+++ b/lib/ide/file-manager/mock-server/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Enso Team <contact@luna-lang.org>"]
 edition = "2018"
 
 [dependencies]
+failure     = "0.1.6"
 futures     = "0.3.1"
 paste       = "0.1.6"
 serde_json  = "1.0"

--- a/lib/ide/file-manager/mock-server/README.md
+++ b/lib/ide/file-manager/mock-server/README.md
@@ -12,4 +12,4 @@ environment variable to customize this behaviour.
 
 The protocol is described in [a separate document](../README.md). Only
 its subset is provided. The following methods are currently implemented:
-`read`, `write`, `exists`, `copyFile`.
+`copyFile`, `exists`, `list`, `read`, `touch`, `write`.


### PR DESCRIPTION
### Pull Request Description
A few fixes and improvements for FM mock server:
* it used wrong function to serialize JSON reply
* now it prints messages on stdout, making debugging of the client much easier
* added two more functions to have more fun when testing integration

### Important Notes
This is a throwaway code used only to facilitate development of #143 and presentation of milestone 0.
It will be removed when cloud provides their implementation.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

