### PR TITLE
Fixes for Rendering on Windows

### DIFF
--- a/lib/core/src/display/shape/text/glyph/system.rs
+++ b/lib/core/src/display/shape/text/glyph/system.rs
@@ -263,4 +263,4 @@ impl GlyphSystem {
 }
 
 const BEFORE_MAIN : &str = include_str!("glyph.glsl");
-const MAIN        : &str = "output_color = color_from_msdf();";
+const MAIN        : &str = "output_color = color_from_msdf(); output_id=uvec4(0,0,0,0);";

--- a/lib/core/src/display/symbol/geometry/compound/sprite.rs
+++ b/lib/core/src/display/symbol/geometry/compound/sprite.rs
@@ -226,7 +226,7 @@ impl SpriteSystemData {
         // FIXME intelligent. For example, we could allow defining output shader fragments,
         // FIXME which will be enabled only if pass of given attachment type was enabled.
         material.add_output ("id", Vector4::<u32>::new(0,0,0,0));
-        material.set_main("output_color = vec4(0.0,0.0,0.0,1.0);");
+        material.set_main("output_color = vec4(0.0,0.0,0.0,1.0); output_id=uvec4(0,0,0,0);");
         material
     }
 


### PR DESCRIPTION
### Pull Request Description
Previously when running examples, the text and sprites were not visible on my machine (Windows, Chrome). This PR, thanks to @wdanilo, fixes the issue.

### Important Notes

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

