### PR TITLE
python version of build.sh

### DIFF
--- a/script/build.py
+++ b/script/build.py
@@ -37,12 +37,12 @@ print(f'Build Working Directory: {repo_root}')
 os.chdir(repo_root)
 
 print('Building with wasm-pack...')
-subprocess.run(['wasm-pack', 'build', '--target', 'web', '--no-typescript', '--out-dir', '../../target/web', 'lib/gui'])
+subprocess.check_call(['wasm-pack', 'build', '--target', 'web', '--no-typescript', '--out-dir', '../../target/web', 'lib/gui'], shell=True)
 patch_file('target/web/gui.js', js_workaround_patcher)
 shutil.move('target/web/gui_bg.wasm', 'target/web/gui.wasm')
 
 # TODO [mwu] It should be possible to drop gzip program dependency by using Python's gzip library.
-subprocess.run(['gzip', '--keep', '--best', '--force', 'target/web/gui.wasm'])
+subprocess.check_call(['gzip', '--keep', '--best', '--force', 'target/web/gui.wasm'], shell=True)
 
 # Note [MWU] We build to provisional location and patch files there before copying, so the backpack don't get errors
 #            from processing unpatched files.

--- a/script/build.py
+++ b/script/build.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+
+from distutils.dir_util import copy_tree
+import os
+import re
+import shutil
+import subprocess
+
+def read_file(path):
+    with open(path) as f:
+        return f.read()
+
+
+def write_file(path, contents):
+    with open(path, 'w') as f:
+        f.write(contents)
+
+
+def patch_file(path, patcher):
+    print(f'Patching {path}')
+    code_to_patch = read_file(path)
+    patched_code = patcher(code_to_patch)
+    write_file(path, patched_code)
+
+
+# Workaround fix by wdanilo, see: https://github.com/rustwasm/wasm-pack/issues/790
+def js_workaround_patcher(code):
+    code = re.sub(r'(?ms)if \(\(typeof URL.*}\);', 'return imports', code)
+    code = re.sub(r'(?ms)if \(typeof module.*let result', 'let result', code)
+    code = f'{code}\nexport function after_load(w,m) {{ wasm = w; init.__wbindgen_wasm_module = m;}}'
+    return code
+
+repo_root = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+
+
+print(f'Build Working Directory: {repo_root}')
+os.chdir(repo_root)
+
+print('Building with wasm-pack...')
+subprocess.run(['wasm-pack', 'build', '--target', 'web', '--no-typescript', '--out-dir', '../../target/web', 'lib/gui'])
+patch_file('target/web/gui.js', js_workaround_patcher)
+shutil.move('target/web/gui_bg.wasm', 'target/web/gui.wasm')
+
+# TODO [mwu] It should be possible to drop gzip program dependency by using Python's gzip library.
+subprocess.run(['gzip', '--keep', '--best', '--force', 'target/web/gui.wasm'])
+
+# Note [MWU] We build to provisional location and patch files there before copying, so the backpack don't get errors
+#            from processing unpatched files.
+#            Also, here we copy into (overwriting), without removing old files. Backpack on Windows does not tolerate
+#            removing files it watches.
+copy_tree('target/web', 'app/src-rust-gen')
+


### PR DESCRIPTION
### Pull Request Description
Currently to build this repository non-portable `build.sh` script is needed. This blocked me for a while from testing examples on Windows.
This PR provides a Python equivalent that should work cross-platform.
Please, test it on your side.

Also, it has some nice properties, like being usable from any working directory.

### Important Notes
I know some of you wanted this to be written in Rust. I tried and decided that it is wrong tool for this task.
Unfortunately, Python remains unbeatable as portable bash replacement. Reasons include proper IDE support (including debugging), a set of mature libraries for dealing with filesystem that work out of the box, being extremely light on iteration time and very simple setup.
(e.g. setting up `cargo script` and working around the MinGW-related issues on Windows took me more time than writing this whole python)

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

