### PR TITLE
Packaging mock File Manager Server

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,6 +119,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./lcov.info
+
   package-fm:
     name: Package File Manager
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,8 @@ jobs:
       - name: Build File Manager Server
         uses: actions-rs/cargo@v1
         with:
-          command: build --release --bin file-manager-server
+          command: build
+          args: --release --bin file-manager-server
       - run: ls -R target/release
 
       - uses: actions/upload-artifact@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,3 +119,40 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           file: ./lcov.info
+  package-fm:
+    name: Package File Manager
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macOS-latest, ubuntu-latest]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2019-11-04
+          override: true
+      - name: Build File Manager Server
+        uses: actions-rs/cargo@v1
+        with:
+          command: build --release --bin file-manager-server
+      - run: ls -R target/release
+
+      - uses: actions/upload-artifact@v1
+        name: Upload Artifacts (Ubuntu)
+        with:
+          name: File Manager Server (Linux)
+          path: target/release/file-manager-server
+        if: matrix.os == 'ubuntu-latest'
+      - uses: actions/upload-artifact@v1
+        name: Upload Artifacts (macOS)
+        with:
+          name: File Manager Server (macOS)
+          path: target/release/file-manager-server
+        if: matrix.os == 'macos-latest'
+      - uses: actions/upload-artifact@v1
+        name: Upload Artifacts (Ubuntu)
+        with:
+          name: File Manager Server (Windows)
+          path: target/release/file-manager-server.exe
+        if: matrix.os == 'windows-latest'


### PR DESCRIPTION
### Pull Request Description
This PR adds to Github Actions a new job that builds mock file manager server bianry and uploads it as a build artifact.

### Important Notes
* While it is a raw binary (no fancy packaging), it seems to be quite portable and not depend on uncommon libraries (though more testing will be needed)
* Hopefully will enable testing of IDE while we wait for "real" file manager server
* More important than initially expected, as IDE do currently require connection to FM to start up

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

