### PR TITLE
Making tests on CI faster by running them in parallel

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,7 @@ jobs:
 
   build:
     name: Build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -82,8 +82,8 @@ jobs:
           path: dist/client/mac/Enso Studio.app
 
 
-  lint:
-    name: Lint
+  check:
+    name: Check
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,10 +110,7 @@ jobs:
 
   test:
     name: Tests
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [windows-latest,macOS-latest,ubuntu-latest]
+    runs-on: macOS-latest
     steps:
       - uses: actions/checkout@v1
 
@@ -135,7 +132,34 @@ jobs:
           node-version: '12.16.1'
 
       - name: Run tests
-        run: node ./run test
+        run: node ./run test --no-wasm
+
+
+  wasm-test:
+    name: WASM Tests
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly-2019-11-04
+          override: true
+
+      - name: Install wasm-pack
+        uses: actions-rs/cargo@v1
+        with:
+          command: install
+          args: wasm-pack --version 0.8.1
+
+      - name: Install Node
+        uses: actions/setup-node@v1
+        with:
+          node-version: '12.16.1'
+
+      - name: Run tests
+        run: node ./run test --no-native
 
 
   # TODO: enable after fixing https://github.com/actions-rs/grcov/issues/50

--- a/build/run.js
+++ b/build/run.js
@@ -165,13 +165,17 @@ commands.start.js = async function() {
 // === Test ===
 
 commands.test = command(`Run test suites`)
-commands.test.rust = async function() {
-    console.log(`Running Rust test suite.`)
-    await run('cargo',['test'])
+commands.test.rust = async function(argv) {
+    if (argv.native) {
+        console.log(`Running Rust test suite.`)
+        await run('cargo',['test'])
+    }
 
-    console.log(`Running Rust visual test suite.`)
-    let args = ['run','--manifest-path=test/Cargo.toml','--bin','test_all','--','--headless','--chrome']
-    await run('cargo',args)
+    if (argv.wasm) {
+        console.log(`Running Rust WASM test suite.`)
+        let args = ['run','--manifest-path=test/Cargo.toml','--bin','test_all','--','--headless','--chrome']
+        await run('cargo',args)
+    }
 }
 
 
@@ -261,7 +265,18 @@ let commandList = Object.keys(commands)
 commandList.sort()
 for (let command of commandList) {
     let config = commands[command]
-    optParser.command(command,config.docs)
+    optParser.command(command,config.docs,(args) => {
+        args.options('native', {
+            describe : 'Run native tests',
+            type     : 'bool',
+            default  : true
+        })
+        args.options('wasm', {
+            describe : 'Run WASM tests',
+            type     : 'bool',
+            default  : true
+        })
+    })
 }
 
 

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -29,7 +29,7 @@ members = [
 ]
 
 [profile.dev]
-opt-level = 2
+opt-level = 0
 lto       = false
 debug     = true
 


### PR DESCRIPTION
### Pull Request Description
- Runs tests only on MacOS, which is fastest setup on GH Actions + saves the actions instances so we dont run out of its limits and dont get queued.
- Runs native and WASM tests in parallel to save the time.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

