### PR TITLE
Fix text selection

### DIFF
--- a/src/js/package-lock.json
+++ b/src/js/package-lock.json
@@ -4249,9 +4249,9 @@
 					}
 				},
 				"yargs": {
-					"version": "15.3.0",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.0.tgz",
-					"integrity": "sha512-g/QCnmjgOl1YJjGsnUg2SatC7NUYEiLXJqxNOQU9qSpjzGtGXda9b+OKccr1kLTy8BN9yqEyqfq5lxlwdc13TA==",
+					"version": "15.3.1",
+					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+					"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
 					"requires": {
 						"cliui": "^6.0.0",
 						"decamelize": "^1.2.0",
@@ -4263,13 +4263,13 @@
 						"string-width": "^4.2.0",
 						"which-module": "^2.0.0",
 						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.0"
+						"yargs-parser": "^18.1.1"
 					}
 				},
 				"yargs-parser": {
-					"version": "18.1.0",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.0.tgz",
-					"integrity": "sha512-o/Jr6JBOv6Yx3pL+5naWSoIA2jJ+ZkMYQG/ie9qFbukBe4uzmBatlXFOiu/tNKRWEtyf+n5w7jc/O16ufqOTdQ==",
+					"version": "18.1.1",
+					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
+					"integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
 					"requires": {
 						"camelcase": "^5.0.0",
 						"decamelize": "^1.2.0"

--- a/src/rust/ensogl/src/display/object.rs
+++ b/src/rust/ensogl/src/display/object.rs
@@ -274,6 +274,17 @@ impl {
             });
         }
     }
+
+    /// Unset all node's callbacks. Because the Node structure may live longer than one's could
+    /// expect (usually to the next scene refresh), it is wise to unset all callbacks when disposing
+    /// object.
+    // TODO[ao] Instead if this, the Node should keep weak references to its children (at least in
+    // "removed" list) and do not extend their lifetime.
+    pub fn clear_callbacks(&mut self) {
+        self.callbacks.on_updated = None;
+        self.callbacks.on_show    = None;
+        self.callbacks.on_hide    = None;
+    }
 }
 
 
@@ -299,9 +310,6 @@ impl {
         self.child_dirty.set_callback(None);
         self.removed_children.set_callback(None);
         self.new_parent_dirty.set();
-//        self.take_parent_bind();
-
-
     }
 
     /// Set parent of the object. If the object already has a parent, the parent would be replaced.
@@ -461,7 +469,6 @@ impl Node {
         })
     }
 }
-
 
 
 // === Getters ===

--- a/src/rust/ensogl/src/display/shape/text/text_field.rs
+++ b/src/rust/ensogl/src/display/shape/text/text_field.rs
@@ -212,11 +212,6 @@ shared! { TextField
             }
         }
 
-        /// Update underlying Display Object.
-        pub fn update(&self) {
-            self.display_object.update()
-        }
-
         /// Check if given point on screen is inside this TextField.
         pub fn is_inside(&self, point:Vector2<f32>) -> bool {
             let position = self.display_object.global_position();

--- a/src/rust/ensogl/src/display/shape/text/text_field/render.rs
+++ b/src/rust/ensogl/src/display/shape/text/text_field/render.rs
@@ -161,7 +161,6 @@ impl TextFieldSprites {
                 }
             }
         }
-        self.display_object.update();
     }
 
     /// Update all displayed cursors with their selections.
@@ -180,7 +179,6 @@ impl TextFieldSprites {
             sprites.selection.clear();
             sprites.selection = generator.generate(&selection);
         }
-        self.display_object.update();
     }
 
     fn update_glyph_line

--- a/src/rust/ensogl/src/display/symbol/gpu/geometry/compound/sprite.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu/geometry/compound/sprite.rs
@@ -117,6 +117,7 @@ impl Drop for SpriteData {
         self.bbox.set(Vector2::new(0.0,0.0));
         self.symbol.surface().instance_scope().dispose(self.instance_id);
         self.display_object.unset_parent();
+        self.display_object.clear_callbacks();
     }
 }
 

--- a/src/rust/ensogl/src/display/symbol/gpu/geometry/compound/sprite.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu/geometry/compound/sprite.rs
@@ -117,6 +117,16 @@ impl Drop for SpriteData {
         self.bbox.set(Vector2::new(0.0,0.0));
         self.symbol.surface().instance_scope().dispose(self.instance_id);
         self.display_object.unset_parent();
+        // TODO[ao] this is a temporary workaround for problem with dropping and creating sprites
+        // in the same frame.
+        //
+        // In detail: detaching display::object::Node from parent does not remove it immediately,
+        // but parent keeps its reference to the next update, and call "hide" during this update.
+        //
+        // The Sprites set on its display object Node a callback setting bbox to (0.0,0.0). When
+        // sprite is removed, the node with its callback persists. If the new sprite is created in
+        // this same frame, it could receive same instance_id as the removed one, so the hide
+        // callback of the old Node sets bbox of the new sprite to (0.0,0.0)
         self.display_object.clear_callbacks();
     }
 }

--- a/src/rust/ide/src/view/text_editor.rs
+++ b/src/rust/ide/src/view/text_editor.rs
@@ -168,7 +168,6 @@ impl TextEditor {
         // https://app.zenhub.com/workspaces/enso-5b57093c92e09f0d21193695/issues/luna/ide/217
         // let padding  = Vector2::new(padding.left + padding.right, padding.top + padding.bottom);
         // self.text_field.set_size(self.dimensions - padding);
-        data.text_field.update();
     }
 }
 

--- a/src/rust/lib/debug-scenes/src/sprite_system.rs
+++ b/src/rust/lib/debug-scenes/src/sprite_system.rs
@@ -29,6 +29,7 @@ fn init(world:&World) {
     let camera        = scene.camera()  ;
     let navigator     = Navigator::new(&scene,&camera);
     let sprite_system = SpriteSystem::new(world);
+
     let sprite1       = sprite_system.new_instance();
     sprite1.size().set(Vector2::new(10.0, 10.0));
     sprite1.mod_position(|t| *t = Vector3::new(5.0, 5.0, 0.0));

--- a/src/rust/lib/debug-scenes/src/text_field.rs
+++ b/src/rust/lib/debug-scenes/src/text_field.rs
@@ -47,7 +47,6 @@ pub fn run_example_text_field() {
         text_field.set_position(Vector3::new(10.0, 600.0, 0.0));
         text_field.jump_cursor(Vector2::new(50.0, -40.0),false);
         world.add_child(&text_field);
-        text_field.update();
 
         world.on_frame(move |_| { let _keep_alive = &text_field; }).forget();
     });

--- a/src/rust/lib/debug-scenes/src/text_typing.rs
+++ b/src/rust/lib/debug-scenes/src/text_typing.rs
@@ -69,5 +69,4 @@ fn animate_text_component
     if start_scrolling <= js_sys::Date::now() {
         text_field.scroll(Vector2::new(0.0,-0.1));
     }
-    text_field.update();
 }


### PR DESCRIPTION
### Pull Request Description
This code fixes the problem with text selection which occurs after recent DisplayObject refactoring.

### Important Notes
The problem was, that detaching Node from parent does not remove it immediately, but parent keeps its reference to the next update, and call "hide" during this update.

The Sprites set on its display object Node a callback setting bbox to 0.0,0.0. When sprite was removed, the node with its callback persisted (as described in previous paragraph); If the new sprite was created in this same frame, it could receive same instance_id as the removed one, so the hide callback of the old Node set bbox of the _new_ sprite to 0.0, 0.0

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

