### PR TITLE
Fix stuck keymask after alt-tabbing

### DIFF
--- a/src/rust/ensogl/src/system/web/text_input.rs
+++ b/src/rust/ensogl/src/system/web/text_input.rs
@@ -32,11 +32,16 @@ mod js {
 
         #[allow(unsafe_code)]
         #[wasm_bindgen(method)]
-        pub fn set_copy_handler(this:&TextInputHandlers, handler:&Closure<dyn FnMut(bool) -> String>);
+        pub fn set_copy_handler
+        (this:&TextInputHandlers, handler:&Closure<dyn FnMut(bool) -> String>);
 
         #[allow(unsafe_code)]
         #[wasm_bindgen(method)]
         pub fn set_paste_handler(this:&TextInputHandlers, handler:&Closure<dyn FnMut(String)>);
+
+        #[allow(unsafe_code)]
+        #[wasm_bindgen(method)]
+        pub fn set_window_blur_handler(this:&TextInputHandlers, handler:&Closure<dyn FnMut()>);
 
         #[allow(unsafe_code)]
         #[wasm_bindgen(method)]
@@ -62,6 +67,9 @@ pub trait CopyHandler = FnMut(bool) -> String + 'static;
 /// The paste handler takes in its argument the text from clipboard to paste.
 pub trait PasteHandler = FnMut(String) + 'static;
 
+/// The window blur handler is called each time browser window loses its focus.
+pub trait WindowBlurHandler = FnMut() + 'static;
+
 /// Keyboard event handler takes event as an argument.
 pub trait KeyboardEventHandler = FnMut(KeyboardEvent) + 'static;
 
@@ -73,6 +81,7 @@ pub struct KeyboardBinding {
     js_handlers      : js::TextInputHandlers,
     copy_handler     : Option<Closure<dyn CopyHandler>>,
     paste_handler    : Option<Closure<dyn PasteHandler>>,
+    blur_handler     : Option<Closure<dyn WindowBlurHandler>>,
     key_down_handler : Option<Closure<dyn KeyboardEventHandler>>,
     key_up_handler   : Option<Closure<dyn KeyboardEventHandler>>,
 }
@@ -85,6 +94,7 @@ impl KeyboardBinding {
             js_handlers      : js::TextInputHandlers::new(),
             copy_handler     : None,
             paste_handler    : None,
+            blur_handler     : None,
             key_down_handler : None,
             key_up_handler   : None
         }
@@ -102,6 +112,13 @@ impl KeyboardBinding {
         let handler_js : Closure<dyn PasteHandler> = Closure::wrap(Box::new(handler));
         self.js_handlers.set_paste_handler(&handler_js);
         self.paste_handler = Some(handler_js);
+    }
+
+    /// Set window blur handler.
+    pub fn set_window_blur_handler<Handler:WindowBlurHandler>(&mut self, handler:Handler) {
+        let handler_js : Closure<dyn WindowBlurHandler> = Closure::wrap(Box::new(handler));
+        self.js_handlers.set_window_blur_handler(&handler_js);
+        self.blur_handler = Some(handler_js);
     }
 
     /// Set keydown handler.
@@ -151,6 +168,9 @@ pub fn bind_frp_to_js_keyboard_actions(frp:&Keyboard) -> KeyboardBinding {
         if let Ok(key) = event.key().parse::<Key>() {
             frp.event.emit(key);
         }
+    }));
+    binding.set_window_blur_handler(enclose!((frp.on_blur => frp) move || {
+        frp.event.emit(())
     }));
     binding
 }

--- a/src/rust/ensogl/src/system/web/text_input/text_input.js
+++ b/src/rust/ensogl/src/system/web/text_input/text_input.js
@@ -33,8 +33,8 @@ export class TextInputHandlers {
     }
 
     // Set callback called each time the browser window lose focus.
-    set_window_blur_handler(handler) {
-        this.window_blur_handler = handler
+    set_window_defocus_handler(handler) {
+        this.window_defocus_handler = handler
     }
 
     // Remove the textarea element and stop handling any events.
@@ -64,7 +64,6 @@ export class TextInputHandlers {
             e.preventDefault()
         })
         this.text_area.addEventListener('blur', e => {
-            console.error("Blurred!")
             this.text_area.focus()
         })
         this.text_area.addEventListener('keydown', e => {
@@ -99,8 +98,8 @@ export class TextInputHandlers {
 
     bind_window_events() {
         window.addEventListener('blur', e => {
-            if (typeof this.window_blur_handler !== 'undefined') {
-                this.window_blur_handler()
+            if (typeof this.window_defocus_handler !== 'undefined') {
+                this.window_defocus_handler()
             }
         })
     }

--- a/src/rust/ensogl/src/system/web/text_input/text_input.js
+++ b/src/rust/ensogl/src/system/web/text_input/text_input.js
@@ -12,6 +12,8 @@ export class TextInputHandlers {
         document.body.appendChild(this.text_area)
         this.text_area.focus()
         this.bind_text_area_events()
+        this.bind_window_events()
+
     }
 
     // Set event handler. The name can be 'keyup' or 'keydown'.
@@ -28,6 +30,11 @@ export class TextInputHandlers {
     // Set paste handler. The paste handler takes the text from clipboard as the only argument.
     set_paste_handler(handler) {
         this.paste_handler = handler
+    }
+
+    // Set callback called each time the browser window lose focus.
+    set_window_blur_handler(handler) {
+        this.window_blur_handler = handler
     }
 
     // Remove the textarea element and stop handling any events.
@@ -55,8 +62,9 @@ export class TextInputHandlers {
         })
         this.text_area.addEventListener('contextmenu', e => {
             e.preventDefault()
-        });
+        })
         this.text_area.addEventListener('blur', e => {
+            console.error("Blurred!")
             this.text_area.focus()
         })
         this.text_area.addEventListener('keydown', e => {
@@ -85,6 +93,14 @@ export class TextInputHandlers {
             e.preventDefault()
             if (typeof this.event_handlers['keyup'] !== 'undefined') {
                 this.event_handlers['keyup'](e)
+            }
+        })
+    }
+
+    bind_window_events() {
+        window.addEventListener('blur', e => {
+            if (typeof this.window_blur_handler !== 'undefined') {
+                this.window_blur_handler()
             }
         })
     }

--- a/src/rust/lib/frp/src/io/keyboard.rs
+++ b/src/rust/lib/frp/src/io/keyboard.rs
@@ -104,36 +104,32 @@ impl KeyMask {
 // === KeyState ===
 // ================
 
-/// A helper structure used for describing specific key state.
-#[derive(Clone,Debug,Default)]
-struct KeyState {
-    key     : Key,
-    pressed : bool,
+/// A helper structure used for describing KeyMask changes.
+#[derive(Clone,Debug)]
+enum KeyMaskChange {
+    Set(Key),
+    Unset(Key),
+    Clear,
 }
 
-impl KeyState {
-    /// Create _pressed_ state for given key.
-    fn key_pressed(key:&Key) -> Self {
-        let pressed = true;
-        let key    = key.clone();
-        KeyState{key,pressed}
-    }
-
-    /// Create _released_ state for given key.
-    fn key_released(key:&Key) -> Self {
-        let pressed = false;
-        let key     = key.clone();
-        KeyState{key,pressed}
-    }
-
-    /// Returns copy of given KeyMask with updated key state.
+impl KeyMaskChange {
+    /// Returns copy of given KeyMask with applied change
     fn updated_mask(&self, mask:&KeyMask) -> KeyMask {
         let mut mask = mask.clone();
-        mask.set_key(&self.key, self.pressed);
+        match self {
+            Self::Set(ref key)   => mask.set_key(key, true),
+            Self::Unset(ref key) => mask.set_key(key, false),
+            Self::Clear          => mask = default()
+        }
         mask
     }
 }
 
+impl Default for KeyMaskChange {
+    fn default() -> Self {
+        Self::Clear
+    }
+}
 
 
 // ================
@@ -147,24 +143,32 @@ pub struct Keyboard {
     pub on_pressed: Dynamic<Key>,
     /// The key released event.
     pub on_released: Dynamic<Key>,
+    /// The "losing focus" event. When we're losing focus we should clear keymask, because we are
+    /// not sure what keys were released during being unfocused.
+    pub on_blur: Dynamic<()>,
     /// The structure holding mask of all of the currently pressed keys.
     pub key_mask: Dynamic<KeyMask>,
 }
 
 impl Default for Keyboard {
     fn default() -> Self {
+        let change_set   = |key:&Key| KeyMaskChange::Set  (key.clone());
+        let change_unset = |key:&Key| KeyMaskChange::Unset(key.clone());
         frp! {
             keyboard.on_pressed        = source();
             keyboard.on_released       = source();
-            keyboard.pressed_state     = on_pressed.map(KeyState::key_pressed);
-            keyboard.released_state    = on_released.map(KeyState::key_released);
-            keyboard.key_state         = pressed_state.merge(&released_state);
+            keyboard.on_blur           = source();
+            keyboard.change_set        = on_pressed .map(change_set);
+            keyboard.change_unset      = on_released.map(change_unset);
+            keyboard.change_clear      = on_blur    .map(|()|  KeyMaskChange::Clear);
+            keyboard.change_set_unset  = change_set.merge(&change_unset);
+            keyboard.change            = change_set_unset.merge(&change_clear);
             keyboard.previous_key_mask = recursive::<KeyMask>();
-            keyboard.key_mask          = key_state.map2(&previous_key_mask,KeyState::updated_mask);
+            keyboard.key_mask          = change.map2(&previous_key_mask,KeyMaskChange::updated_mask);
         }
         previous_key_mask.initialize(&key_mask);
 
-        Keyboard { on_pressed,on_released,key_mask}
+        Keyboard { on_pressed,on_released,on_blur,key_mask}
     }
 }
 

--- a/src/rust/lib/frp/src/io/keyboard.rs
+++ b/src/rust/lib/frp/src/io/keyboard.rs
@@ -145,7 +145,7 @@ pub struct Keyboard {
     pub on_released: Dynamic<Key>,
     /// The "losing focus" event. When we're losing focus we should clear keymask, because we are
     /// not sure what keys were released during being unfocused.
-    pub on_blur: Dynamic<()>,
+    pub on_defocus: Dynamic<()>,
     /// The structure holding mask of all of the currently pressed keys.
     pub key_mask: Dynamic<KeyMask>,
 }
@@ -157,10 +157,10 @@ impl Default for Keyboard {
         frp! {
             keyboard.on_pressed        = source();
             keyboard.on_released       = source();
-            keyboard.on_blur           = source();
+            keyboard.on_defocus        = source();
             keyboard.change_set        = on_pressed .map(change_set);
             keyboard.change_unset      = on_released.map(change_unset);
-            keyboard.change_clear      = on_blur    .map(|()|  KeyMaskChange::Clear);
+            keyboard.change_clear      = on_defocus .map(|()| KeyMaskChange::Clear);
             keyboard.change_set_unset  = change_set.merge(&change_unset);
             keyboard.change            = change_set_unset.merge(&change_clear);
             keyboard.previous_key_mask = recursive::<KeyMask>();
@@ -168,7 +168,7 @@ impl Default for Keyboard {
         }
         previous_key_mask.initialize(&key_mask);
 
-        Keyboard { on_pressed,on_released,on_blur,key_mask}
+        Keyboard { on_pressed,on_released,on_defocus,key_mask}
     }
 }
 


### PR DESCRIPTION
### Pull Request Description
After pressing Alt-tab editor did not received keyup events so the keymask was stuck with pressed-alt state. To fix that, we clear the mask each time window lose focus.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

