### PR TITLE
Improve cursor blinking

### DIFF
--- a/src/rust/ensogl/src/display/shape/text/text_field/render.rs
+++ b/src/rust/ensogl/src/display/shape/text/text_field/render.rs
@@ -23,6 +23,7 @@ use crate::display::world::World;
 use nalgebra::Vector2;
 use nalgebra::Vector3;
 use crate::math::topology::unit::PixelDistance;
+use crate::display::Glsl;
 
 
 // =======================
@@ -75,7 +76,7 @@ impl TextFieldSprites {
         let window_size       = properties.size;
         let color             = properties.base_color;
         let selection_system  = Self::create_selection_system(world);
-        let cursor_system     = Self::create_cursor_system(world,line_height);
+        let cursor_system     = Self::create_cursor_system(world,line_height,&color);
         let cursors           = Vec::new();
         let mut glyph_system  = GlyphSystem::new(world,font.clone_ref());
         let display_object    = display::object::Node::new(Logger::new("RenderedContent"));
@@ -96,12 +97,14 @@ impl TextFieldSprites {
             line_height,display_object,assignment}
     }
 
-    fn create_cursor_system(world:&World,line_height:f32) -> ShapeSystem {
-        const WIDTH:f32 = 2.0;
-        const COLOR_FUNCTION:&str = "fract(input_time / 1000.0) < 0.5 ? vec4(0.0,0.0,0.0,1.0) : vec4(0.0,0.0,0.0,0.0)";
-//        const COLOR_FUNCTION:&str = "vec4(0.0,0.0,0.0,1.0)";
+    fn create_cursor_system(world:&World,line_height:f32,color:&Vector4<f32>) -> ShapeSystem {
+        const WIDTH:f32         = 2.0;
+        const COLOR_HIDDEN:&str = "vec4(0.0,0.0,0.0,0.0)";
+        let color_glsl:Glsl     = color.into();
+        let color_function      = format!("fract(input_time / 1000.0) < 0.5 ? {} : {}",
+            color_glsl,COLOR_HIDDEN);
         let cursor_definition     = Rect(Vector2::new(WIDTH.px(),line_height.px()));
-        let cursor_definition     = cursor_definition.fill(COLOR_FUNCTION);
+        let cursor_definition     = cursor_definition.fill(color_function);
         ShapeSystem::new(world,&cursor_definition)
     }
 

--- a/src/rust/ensogl/src/display/shape/text/text_field/render.rs
+++ b/src/rust/ensogl/src/display/shape/text/text_field/render.rs
@@ -22,7 +22,7 @@ use crate::display::world::World;
 
 use nalgebra::Vector2;
 use nalgebra::Vector3;
-
+use crate::math::topology::unit::PixelDistance;
 
 
 // =======================
@@ -74,8 +74,8 @@ impl TextFieldSprites {
         let line_height       = properties.text_size;
         let window_size       = properties.size;
         let color             = properties.base_color;
-        let cursor_system     = Self::create_cursor_system(world,line_height);
         let selection_system  = Self::create_selection_system(world);
+        let cursor_system     = Self::create_cursor_system(world,line_height);
         let cursors           = Vec::new();
         let mut glyph_system  = GlyphSystem::new(world,font.clone_ref());
         let display_object    = display::object::Node::new(Logger::new("RenderedContent"));
@@ -97,8 +97,11 @@ impl TextFieldSprites {
     }
 
     fn create_cursor_system(world:&World,line_height:f32) -> ShapeSystem {
-        const WIDTH_FUNCTION:&str = "fract(input_time / 1000.0) < 0.5 ? 2.0 : 0.0";
-        let cursor_definition     = Rect((WIDTH_FUNCTION,line_height.px()));
+        const WIDTH:f32 = 2.0;
+        const COLOR_FUNCTION:&str = "fract(input_time / 1000.0) < 0.5 ? vec4(0.0,0.0,0.0,1.0) : vec4(0.0,0.0,0.0,0.0)";
+//        const COLOR_FUNCTION:&str = "vec4(0.0,0.0,0.0,1.0)";
+        let cursor_definition     = Rect(Vector2::new(WIDTH.px(),line_height.px()));
+        let cursor_definition     = cursor_definition.fill(COLOR_FUNCTION);
         ShapeSystem::new(world,&cursor_definition)
     }
 


### PR DESCRIPTION
### Pull Request Description
Before blinking cursor was done by setting width to 0.0, but this leaves a very-thin line instead of disappearing cursor entirely.

This fixes this, and make the blinking by setting color to transparent instead of setting width.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

