### PR TITLE
Mac and Windows shortcuts fixes

### DIFF
--- a/src/rust/ensogl/src/display/shape/text/text_field/frp/keyboard.rs
+++ b/src/rust/ensogl/src/display/shape/text/text_field/frp/keyboard.rs
@@ -131,7 +131,11 @@ impl TextFieldKeyboardFrp {
             text_field.upgrade().for_each(|text_field| {
                 if let Key::Character(string) = key {
                     let modifiers = &[Key::Control,Key::Alt];
-                    if !modifiers.iter().any(|k| mask.has_key(k)) {
+                    let is_modifier  = modifiers.iter().any(|k| mask.has_key(k));
+                    let is_alt_graph = mask.has_key(&Key::AltGraph);
+                    // On Windows AltGraph is emitted as both AltGraph and Ctrl. Therefore we don't
+                    // care about modifiers when AltGraph is pressed.
+                    if  !is_modifier || is_alt_graph {
                         text_field.write(string);
                     }
                 }

--- a/src/rust/lib/frp/src/io/keyboard.rs
+++ b/src/rust/lib/frp/src/io/keyboard.rs
@@ -167,7 +167,7 @@ impl Default for Keyboard {
         frp! {
             keyboard.on_pressed        = source();
             keyboard.on_released       = source();
-            keyboard.on_blur           = source();
+            keyboard.on_defocus        = source();
             keyboard.change_set        = on_pressed .map(KeyMaskChange::on_pressed);
             keyboard.change_unset      = on_released.map(KeyMaskChange::on_released);
             keyboard.change_clear      = on_defocus .map(|()| KeyMaskChange::on_defocus());

--- a/src/rust/lib/frp/src/io/keyboard.rs
+++ b/src/rust/lib/frp/src/io/keyboard.rs
@@ -113,6 +113,18 @@ enum KeyMaskChange {
 }
 
 impl KeyMaskChange {
+    fn on_pressed(key:&Key) -> Self { Self::Set(key.clone()) }
+    fn on_defocus()         -> Self { Self::Clear            }
+
+    fn on_released(key:&Key) -> Self {
+        match key {
+            // The very special case: pressing CMD on MacOS makes all the keyup events for letters
+            // lost. Therefore for CMD releasing we must clear keymask.
+            Key::Meta => Self::Clear,
+            other     => Self::Unset(other.clone())
+        }
+    }
+
     /// Returns copy of given KeyMask with applied change
     fn updated_mask(&self, mask:&KeyMask) -> KeyMask {
         let mut mask = mask.clone();
@@ -152,15 +164,13 @@ pub struct Keyboard {
 
 impl Default for Keyboard {
     fn default() -> Self {
-        let change_set   = |key:&Key| KeyMaskChange::Set  (key.clone());
-        let change_unset = |key:&Key| KeyMaskChange::Unset(key.clone());
         frp! {
             keyboard.on_pressed        = source();
             keyboard.on_released       = source();
-            keyboard.on_defocus        = source();
-            keyboard.change_set        = on_pressed .map(change_set);
-            keyboard.change_unset      = on_released.map(change_unset);
-            keyboard.change_clear      = on_defocus .map(|()| KeyMaskChange::Clear);
+            keyboard.on_blur           = source();
+            keyboard.change_set        = on_pressed .map(KeyMaskChange::on_pressed);
+            keyboard.change_unset      = on_released.map(KeyMaskChange::on_released);
+            keyboard.change_clear      = on_defocus .map(|()| KeyMaskChange::on_defocus());
             keyboard.change_set_unset  = change_set.merge(&change_unset);
             keyboard.change            = change_set_unset.merge(&change_clear);
             keyboard.previous_key_mask = recursive::<KeyMask>();


### PR DESCRIPTION
### Pull Request Description
These are two fixes for pressing shortcuts in MacOS and Windows:
* in MacOS pressing key with CMD causes the keyup event to be missed
* on Windows pressing AltGraph also emits Control keydown.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

