### PR TITLE
Fix Navigator

### DIFF
--- a/src/rust/ensogl/src/control/event_loop.rs
+++ b/src/rust/ensogl/src/control/event_loop.rs
@@ -49,10 +49,12 @@ impl EventLoop {
     fn init(self) -> Self {
         let data = Rc::downgrade(&self.rc);
         let main = move |time_ms| { data.upgrade().map(|t| t.borrow_mut().run(time_ms)); };
+        let mut id = default();
         with(self.rc.borrow_mut(), |mut data| {
             data.main = Some(Closure::new(main));
-            web::request_animation_frame(&data.main.as_ref().unwrap());
+            id = web::request_animation_frame(&data.main.as_ref().unwrap());
         });
+        self.rc.borrow_mut().main_id = id;
         self
     }
 


### PR DESCRIPTION
### Pull Request Description
This PR fixes two issues of `MouseManager` and `EventLoop` causing them to not remove their registered callbacks when they are dropped.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

