### PR TITLE
Fix drawing instance with empty buffers

### DIFF
--- a/src/rust/ensogl/src/display/symbol/gpu.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu.rs
@@ -272,9 +272,12 @@ impl {
                 let instance_count = self.surface.instance_scope().size() as i32;
 
                 self.stats.inc_draw_call_count();
-                self.context.draw_arrays_instanced(mode,first,count,instance_count);
+                if instance_count > 0 {
+                    self.context.draw_arrays_instanced(mode,first,count,instance_count);
+                } else {
+                    self.context.draw_arrays(mode,first,count);
+                }
             });
-
         })
     }
 }}

--- a/src/rust/ensogl/src/display/symbol/gpu.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu.rs
@@ -270,7 +270,6 @@ impl {
                 let first          = 0;
                 let count          = self.surface.point_scope().size()    as i32;
                 let instance_count = self.surface.instance_scope().size() as i32;
-                let instance_count = std::cmp::max(instance_count,1);
 
                 self.stats.inc_draw_call_count();
                 self.context.draw_arrays_instanced(mode,first,count,instance_count);

--- a/src/rust/ensogl/src/system/gpu/data/buffer.rs
+++ b/src/rust/ensogl/src/system/gpu/data/buffer.rs
@@ -90,6 +90,7 @@ impl<T:Storable> {
             stats.inc_buffer_count();
             let mut_dirty     = MutDirty::new(logger.sub("mut_dirty"),Callback(on_mut));
             let resize_dirty  = ResizeDirty::new(logger.sub("resize_dirty"),Callback(on_resize));
+            resize_dirty.set();
             let on_resize_fn  = on_resize_fn(resize_dirty.clone_ref());
             let on_mut_fn     = on_mut_fn(mut_dirty.clone_ref());
             let buffer        = ObservableVec::new(on_mut_fn,on_resize_fn);


### PR DESCRIPTION
### Pull Request Description
This code was developed as a fix for occuring "crashes" on Windows, which were in fact a "contextLost" events of WebGl.

When we had Symbol without any instance created in it, we could get some empty buffers in instance scope. But the empty buffers were not marked as dirty on creation, so we didn't upload the "empty" data. Additionally, the method where we call the actual rendering assumed that there is always at least one instance. So it read one instance from uninitialized buffer, what left WebGl in some undefined state.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

