### PR TITLE
Add port drawing.

### DIFF
--- a/src/js/package-lock.json
+++ b/src/js/package-lock.json
@@ -1046,9 +1046,9 @@
 			}
 		},
 		"@octokit/endpoint": {
-			"version": "5.5.3",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-5.5.3.tgz",
-			"integrity": "sha512-EzKwkwcxeegYYah5ukEeAI/gYRLv2Y9U5PpIsseGSFDk+G3RbipQGBs8GuYS1TLCtQaqoO66+aQGtITPalxsNQ==",
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-6.0.0.tgz",
+			"integrity": "sha512-3nx+MEYoZeD0uJ+7F/gvELLvQJzLXhep2Az0bBSXagbApDvDW0LWwpnAIY/hb0Jwe17A0fJdz0O12dPh05cj7A==",
 			"dev": true,
 			"requires": {
 				"@octokit/types": "^2.0.0",
@@ -1114,13 +1114,13 @@
 			}
 		},
 		"@octokit/request": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.2.tgz",
-			"integrity": "sha512-7NPJpg19wVQy1cs2xqXjjRq/RmtSomja/VSWnptfYwuBxLdbYh2UjhGi0Wx7B1v5Iw5GKhfFDQL7jM7SSp7K2g==",
+			"version": "5.3.4",
+			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-5.3.4.tgz",
+			"integrity": "sha512-qyj8G8BxQyXjt9Xu6NvfvOr1E0l35lsXtwm3SopsYg/JWXjlsnwqLc8rsD2OLguEL/JjLfBvrXr4az7z8Lch2A==",
 			"dev": true,
 			"requires": {
-				"@octokit/endpoint": "^5.5.0",
-				"@octokit/request-error": "^1.0.1",
+				"@octokit/endpoint": "^6.0.0",
+				"@octokit/request-error": "^2.0.0",
 				"@octokit/types": "^2.0.0",
 				"deprecation": "^2.0.0",
 				"is-plain-object": "^3.0.0",
@@ -1129,6 +1129,17 @@
 				"universal-user-agent": "^5.0.0"
 			},
 			"dependencies": {
+				"@octokit/request-error": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-2.0.0.tgz",
+					"integrity": "sha512-rtYicB4Absc60rUv74Rjpzek84UbVHGHJRu4fNVlZ1mCcyUPPuzFfG9Rn6sjHrd95DEsmjSt1Axlc699ZlbDkw==",
+					"dev": true,
+					"requires": {
+						"@octokit/types": "^2.0.0",
+						"deprecation": "^2.0.0",
+						"once": "^1.4.0"
+					}
+				},
 				"is-plain-object": {
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-3.0.0.tgz",
@@ -1191,9 +1202,9 @@
 			}
 		},
 		"@octokit/types": {
-			"version": "2.5.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.5.0.tgz",
-			"integrity": "sha512-KEnLwOfdXzxPNL34fj508bhi9Z9cStyN7qY1kOfVahmqtAfrWw6Oq3P4R+dtsg0lYtZdWBpUrS/Ixmd5YILSww==",
+			"version": "2.5.1",
+			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-2.5.1.tgz",
+			"integrity": "sha512-q4Wr7RexkPRrkQpXzUYF5Fj/14Mr65RyOHj6B9d/sQACpqGcStkHZj4qMEtlMY5SnD/69jlL9ItGPbDM0dR/dA==",
 			"dev": true,
 			"requires": {
 				"@types/node": ">= 8"
@@ -1982,8 +1993,7 @@
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-			"dev": true
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"batch": {
 			"version": "0.6.1",
@@ -2032,13 +2042,24 @@
 			}
 		},
 		"bl": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.1.tgz",
-			"integrity": "sha512-FL/TdvchukRCuWVxT0YMO/7+L5TNeNrVFvRU2IY63aUyv9mpt8splf2NEr6qXtPo5fya5a66YohQKvGNmLrWNA==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
+			"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
 			"requires": {
+				"buffer": "^5.5.0",
+				"inherits": "^2.0.4",
 				"readable-stream": "^3.4.0"
 			},
 			"dependencies": {
+				"buffer": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.5.0.tgz",
+					"integrity": "sha512-9FTEDjLjwoAkEwyMGDjYJQN2gfRgOKBKRfiglhvibGbpeeU/pQn1bJxQqm32OD/AIeEuHxU9roxXxg34Byp/Ww==",
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
+				},
 				"readable-stream": {
 					"version": "3.6.0",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -2386,6 +2407,11 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
 			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg=="
+		},
+		"buffer-crc32": {
+			"version": "0.2.13",
+			"resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+			"integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
 		},
 		"buffer-equal": {
 			"version": "0.0.1",
@@ -4157,9 +4183,9 @@
 			},
 			"dependencies": {
 				"@types/node": {
-					"version": "12.12.30",
-					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.30.tgz",
-					"integrity": "sha512-sz9MF/zk6qVr3pAnM0BSQvYIBK44tS75QC5N+VbWSE4DjCV/pJ+UzCW/F+vVnl7TkOPcuwQureKNtSSwjBTaMg=="
+					"version": "12.12.31",
+					"resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.31.tgz",
+					"integrity": "sha512-T+wnJno8uh27G9c+1T+a1/WYCHzLeDqtsGJkoEdSp2X8RTh3oOCZQcUnjAx90CS8cmmADX51O0FI/tu9s0yssg=="
 				}
 			}
 		},
@@ -4226,43 +4252,6 @@
 					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
 					"requires": {
 						"has-flag": "^4.0.0"
-					}
-				},
-				"wrap-ansi": {
-					"version": "6.2.0",
-					"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
-					"integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
-					"requires": {
-						"ansi-styles": "^4.0.0",
-						"string-width": "^4.1.0",
-						"strip-ansi": "^6.0.0"
-					}
-				},
-				"yargs": {
-					"version": "15.3.1",
-					"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
-					"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
-					"requires": {
-						"cliui": "^6.0.0",
-						"decamelize": "^1.2.0",
-						"find-up": "^4.1.0",
-						"get-caller-file": "^2.0.1",
-						"require-directory": "^2.1.1",
-						"require-main-filename": "^2.0.0",
-						"set-blocking": "^2.0.0",
-						"string-width": "^4.2.0",
-						"which-module": "^2.0.0",
-						"y18n": "^4.0.0",
-						"yargs-parser": "^18.1.1"
-					}
-				},
-				"yargs-parser": {
-					"version": "18.1.1",
-					"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.1.tgz",
-					"integrity": "sha512-KRHEsOM16IX7XuLnMOqImcPNbLVXMNHYAoFc3BKR8Ortl5gzDbtXvvEoGx9imk5E+X1VeNKNlcHr8B8vi+7ipA==",
-					"requires": {
-						"camelcase": "^5.0.0",
-						"decamelize": "^1.2.0"
 					}
 				}
 			}
@@ -4843,14 +4832,14 @@
 			}
 		},
 		"extract-zip": {
-			"version": "1.6.7",
-			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
-			"integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.7.0.tgz",
+			"integrity": "sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==",
 			"requires": {
-				"concat-stream": "1.6.2",
-				"debug": "2.6.9",
-				"mkdirp": "0.5.1",
-				"yauzl": "2.4.1"
+				"concat-stream": "^1.6.2",
+				"debug": "^2.6.9",
+				"mkdirp": "^0.5.4",
+				"yauzl": "^2.10.0"
 			},
 			"dependencies": {
 				"debug": {
@@ -4859,6 +4848,19 @@
 					"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
 					"requires": {
 						"ms": "2.0.0"
+					}
+				},
+				"minimist": {
+					"version": "1.2.5",
+					"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+					"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+				},
+				"mkdirp": {
+					"version": "0.5.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+					"integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
+					"requires": {
+						"minimist": "^1.2.5"
 					}
 				},
 				"ms": {
@@ -4930,9 +4932,9 @@
 			}
 		},
 		"fd-slicer": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-			"integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+			"integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
 			"requires": {
 				"pend": "~1.2.0"
 			}
@@ -6118,9 +6120,9 @@
 			}
 		},
 		"glob-parent": {
-			"version": "5.1.0",
-			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.0.tgz",
-			"integrity": "sha512-qjtRgnIVmOfnKUE3NJAQEdk+lKrxfw8t5ke7SXtfMTHcjsBfOfWXCQfdb30zfDoZQ2IRSIiidmjtbHZPZ++Ihw==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
+			"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
 			"dev": true,
 			"requires": {
 				"is-glob": "^4.0.1"
@@ -6577,8 +6579,7 @@
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-			"dev": true
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -7134,9 +7135,9 @@
 			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isbinaryfile": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.4.tgz",
-			"integrity": "sha512-pEutbN134CzcjlLS1myKX/uxNjwU5eBVSprvkpv3+3dqhBHUZLIWJQowC40w5c0Zf19vBY8mrZl88y5J4RAPbQ=="
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/isbinaryfile/-/isbinaryfile-4.0.5.tgz",
+			"integrity": "sha512-Jvz0gpTh1AILHMCBUyqq7xv1ZOQrxTDwyp1/QUq1xFpOBvp4AH5uEobPePJht8KnBGqQIH7We6OR73mXsjG0cA=="
 		},
 		"isexe": {
 			"version": "2.0.0",
@@ -7932,6 +7933,11 @@
 				"minimist": "0.0.8"
 			}
 		},
+		"mkdirp-classic": {
+			"version": "0.5.2",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
+			"integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g=="
+		},
 		"mkdirp-promise": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/mkdirp-promise/-/mkdirp-promise-5.0.1.tgz",
@@ -8078,9 +8084,9 @@
 			"dev": true
 		},
 		"node-fetch-npm": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.3.tgz",
-			"integrity": "sha512-DgwoKEsqLnFZtk3ap7GWBHcHwnUhsNmQqEDcdjfQ8GofLEFJ081NAd4Uin3R7RFZBWVJCwHISw1oaEqPgSLloA==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/node-fetch-npm/-/node-fetch-npm-2.0.4.tgz",
+			"integrity": "sha512-iOuIQDWDyjhv9qSDrj9aq/klt6F9z1p2otB3AV7v3zBDcL/x+OfGsvGQZZCcMZbUf4Ujw1xGNQkjvGnVT22cKg==",
 			"dev": true,
 			"requires": {
 				"encoding": "^0.1.11",
@@ -8232,9 +8238,9 @@
 			}
 		},
 		"npm-lifecycle": {
-			"version": "3.1.4",
-			"resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.4.tgz",
-			"integrity": "sha512-tgs1PaucZwkxECGKhC/stbEgFyc3TGh2TJcg2CDr6jbvQRdteHNhmMeljRzpe4wgFAXQADoy1cSqqi7mtiAa5A==",
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/npm-lifecycle/-/npm-lifecycle-3.1.5.tgz",
+			"integrity": "sha512-lDLVkjfZmvmfvpvBzA4vzee9cn+Me4orq0QF8glbswJVEbIcSNWib7qGOffolysc3teCqbbPZZkzbr3GQZTL1g==",
 			"dev": true,
 			"requires": {
 				"byline": "^5.0.0",
@@ -9047,9 +9053,9 @@
 			"dev": true
 		},
 		"psl": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/psl/-/psl-1.7.0.tgz",
-			"integrity": "sha512-5NsSEDv8zY70ScRnOTn7bK7eanl2MvFrOrS/R6x+dBt5g1ghnj9Zv90kO8GwT8gxcu2ANyFprnFYB85IogIJOQ=="
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -9243,11 +9249,11 @@
 			},
 			"dependencies": {
 				"json5": {
-					"version": "2.1.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.1.tgz",
-					"integrity": "sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==",
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.2.tgz",
+					"integrity": "sha512-MoUOQ4WdiN3yxhm7NEVJSJrieAo5hNSLQ5sj05OTRHPL9HOBy8u4Bu88jsC1jvqAdN+E1bJmsUcZH+1HQxliqQ==",
 					"requires": {
-						"minimist": "^1.2.0"
+						"minimist": "^1.2.5"
 					}
 				},
 				"minimist": {
@@ -10754,12 +10760,12 @@
 			}
 		},
 		"tar-fs": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.0.tgz",
-			"integrity": "sha512-vaY0obB6Om/fso8a8vakQBzwholQ7v5+uy+tF3Ozvxv1KNezmVQAiWtcNmMHFSFPqL3dJA8ha6gdtFbfX9mcxA==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
+			"integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
 			"requires": {
 				"chownr": "^1.1.1",
-				"mkdirp": "^0.5.1",
+				"mkdirp-classic": "^0.5.2",
 				"pump": "^3.0.0",
 				"tar-stream": "^2.0.0"
 			}
@@ -12203,9 +12209,9 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="
 		},
 		"yargs": {
-			"version": "15.3.0",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.0.tgz",
-			"integrity": "sha512-g/QCnmjgOl1YJjGsnUg2SatC7NUYEiLXJqxNOQU9qSpjzGtGXda9b+OKccr1kLTy8BN9yqEyqfq5lxlwdc13TA==",
+			"version": "15.3.1",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-15.3.1.tgz",
+			"integrity": "sha512-92O1HWEjw27sBfgmXiixJWT5hRBp2eobqXicLtPBIDBhYB+1HpwZlXmbW2luivBJHBzki+7VyCLRtAkScbTBQA==",
 			"requires": {
 				"cliui": "^6.0.0",
 				"decamelize": "^1.2.0",
@@ -12217,7 +12223,7 @@
 				"string-width": "^4.2.0",
 				"which-module": "^2.0.0",
 				"y18n": "^4.0.0",
-				"yargs-parser": "^18.1.0"
+				"yargs-parser": "^18.1.1"
 			},
 			"dependencies": {
 				"ansi-regex": {
@@ -12328,20 +12334,21 @@
 			}
 		},
 		"yargs-parser": {
-			"version": "18.1.0",
-			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.0.tgz",
-			"integrity": "sha512-o/Jr6JBOv6Yx3pL+5naWSoIA2jJ+ZkMYQG/ie9qFbukBe4uzmBatlXFOiu/tNKRWEtyf+n5w7jc/O16ufqOTdQ==",
+			"version": "18.1.2",
+			"resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-18.1.2.tgz",
+			"integrity": "sha512-hlIPNR3IzC1YuL1c2UwwDKpXlNFBqD1Fswwh1khz5+d8Cq/8yc/Mn0i+rQXduu8hcrFKvO7Eryk+09NecTQAAQ==",
 			"requires": {
 				"camelcase": "^5.0.0",
 				"decamelize": "^1.2.0"
 			}
 		},
 		"yauzl": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
-			"integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+			"version": "2.10.0",
+			"resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+			"integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
 			"requires": {
-				"fd-slicer": "~1.0.1"
+				"buffer-crc32": "~0.2.3",
+				"fd-slicer": "~1.1.0"
 			}
 		}
 	}

--- a/src/rust/ensogl/src/display/shape/compound.rs
+++ b/src/rust/ensogl/src/display/shape/compound.rs
@@ -1,1 +1,3 @@
 //! Root module for complex, often used shapes.
+
+pub mod port;

--- a/src/rust/ensogl/src/display/shape/compound/port.rs
+++ b/src/rust/ensogl/src/display/shape/compound/port.rs
@@ -102,7 +102,6 @@ impl Port{
         if show_debug{
             let debug_circle = circle_inner.fill(Srgba::new(0.1,0.1,0.1,0.5));
             (triangle_rounded + debug_circle).into()
-
         } else{
             triangle_rounded.into()
         }
@@ -133,12 +132,11 @@ impl Port{
 
         let circle_outer = Circle(outer_radius.px());
 
-        let triangle_rounded = Intersection(triangle circle_outer.clone()).fill(spec.color);
+        let triangle_rounded = Intersection(triangle,circle_outer.clone()).fill(spec.color);
 
         if show_debug{
             let debug_circle = circle_outer.fill(Srgba::new(0.1,0.1,0.1, 0.5));
             (triangle_rounded + debug_circle).into()
-
         } else{
             triangle_rounded.into()
         }

--- a/src/rust/ensogl/src/display/shape/compound/port.rs
+++ b/src/rust/ensogl/src/display/shape/compound/port.rs
@@ -1,0 +1,146 @@
+//! This module defines the shapes required for drawing node ports.
+
+use crate::data::color::*;
+use crate::display::shape::*;
+use crate::display::shape::primitive::def::modifier::immutable::*;
+use crate::display::shape::primitive::def::primitive::*;
+use crate::prelude::*;
+
+use crate::display::shape::primitive::def::class::ShapeOps;
+use crate::math::circle_segment::CircleSegment;
+use crate::math::topology::unit::AngleOps;
+use crate::math::topology::unit::Distance;
+use crate::math::topology::unit::PixelDistance;
+use crate::math::topology::unit::Pixels;
+use crate::math::topology::unit::{Angle, Degrees};
+
+use nalgebra::Vector2;
+
+
+
+// ===========================
+// === Port Specification ===
+// ===========================
+
+/// Indicates whether a port is incoming or outgoing.
+#[derive(Clone,Copy,Debug,Eq,PartialEq)]
+pub enum PortDirection {
+    /// Indicates port facing towards the center of its inner circle.
+    Inwards,
+    /// Indicates port facing away from the center of its inner circle.
+    Outwards,
+}
+
+
+/// Defines the properties of a port shape and can then
+/// be used to build the port shape.
+///
+/// Ports are constructed around an inner circle, and thus
+/// most measurements are in degrees, which are measured around
+/// a inner circle, that is defined by the `inner_radius`.
+#[derive(Clone,Copy,Debug)]
+pub struct PortSpecification{
+    /// Height of the port.
+    pub height      : f32,
+    /// Width of the port in degrees.
+    pub width       : Angle<Degrees>,
+    /// Radius of the inner circle that the port is constructed around.
+    pub inner_radius: f32,
+    /// Direction the port is facing.
+    pub direction   : PortDirection,
+    /// Location of the port along the inner circle.
+    pub location    : Angle<Degrees>,
+    /// Fill colour of the port.
+    pub color       : Srgb<f32>,
+}
+
+
+// ============
+// === Port ===
+// =============
+
+#[derive(Clone,Copy,Debug)]
+/// Dummy struct for port construction.
+pub struct Port;
+
+impl Port{
+    /// Construct a port according to the given `PortSpecification`.
+    #[allow(clippy::new_ret_no_self)]
+    pub fn new(spec:PortSpecification) -> AnyShape{
+        let show_debug = false;
+        match spec.direction{
+            PortDirection::Inwards  => Port::new_port_inwards(spec, show_debug),
+            PortDirection::Outwards => Port::new_port_outwards(spec, show_debug),
+
+        }
+    }
+
+    /// Construct an outwards facing port.
+    fn new_port_outwards(spec:PortSpecification, show_debug:bool) -> AnyShape{
+        debug_assert_eq!(spec.direction,PortDirection::Outwards);
+
+        let inner_radius = spec.inner_radius;
+
+        let segment = CircleSegment::new(inner_radius,spec.width.radians());
+
+        // Create the triangle (pointing up)
+        let tri_base   = inner_radius - segment.sagitta();
+        let tri_height = spec.height + segment.sagitta();
+        let tri_width  = segment.chord_length();
+
+        let triangle = Triangle(tri_width,tri_height);
+
+        // Move the triangle to its base position and rotate it to its final destination.
+        let offfset: Vector2<Distance<Pixels>> =  Vector2::new(Distance::new(0.0),Distance::new(tri_base));
+        let triangle = Translate(triangle,offfset);
+        let triangle = Rotation(triangle,spec.location.radians());
+
+        let circle_inner = Circle(spec.inner_radius.px());
+
+        let triangle_rounded = Difference(triangle,circle_inner.clone()).fill(spec.color);
+
+        if show_debug{
+            let debug_circle = circle_inner.fill(Srgba::new(0.1,0.1,0.1,0.5));
+            (triangle_rounded + debug_circle).into()
+
+        } else{
+            triangle_rounded.into()
+        }
+
+    }
+
+    /// Construct an inwards facing port.
+    fn new_port_inwards(spec:PortSpecification, show_debug:bool) -> AnyShape{
+        debug_assert_eq!(spec.direction,PortDirection::Inwards);
+
+        let outer_radius = spec.inner_radius + spec.height;
+
+        let segment = CircleSegment::new(outer_radius,spec.width.radians());
+
+        // Create the triangle (pointing up)
+        let tri_height =  spec.height;
+        let tri_width  = segment.chord_length() * ((outer_radius + segment.sagitta()) / outer_radius);
+
+        // Point the triangle down
+        let triangle = Triangle(tri_width, tri_height);
+        let triangle = Rotation(triangle, 180.0.deg().radians());
+
+        // Move the triangle to its base position and rotate it to its final destination.
+        let tri_base = outer_radius;
+        let offfset: Vector2<Distance<Pixels>> =  Vector2::new(Distance::new(0.0),Distance::new(tri_base));
+        let triangle = Translate(triangle,offfset);
+        let triangle = Rotation(triangle,spec.location.radians());
+
+        let circle_outer = Circle(outer_radius.px());
+
+        let triangle_rounded = Intersection(triangle circle_outer.clone()).fill(spec.color);
+
+        if show_debug{
+            let debug_circle = circle_outer.fill(Srgba::new(0.1,0.1,0.1, 0.5));
+            (triangle_rounded + debug_circle).into()
+
+        } else{
+            triangle_rounded.into()
+        }
+    }
+}

--- a/src/rust/ensogl/src/display/shape/compound/port.rs
+++ b/src/rust/ensogl/src/display/shape/compound/port.rs
@@ -2,20 +2,16 @@
 
 use crate::data::color::*;
 use crate::display::shape::*;
-use crate::display::shape::primitive::def::modifier::immutable::*;
-use crate::display::shape::primitive::def::primitive::*;
 use crate::prelude::*;
-
-use crate::display::shape::primitive::def::class::ShapeOps;
-use crate::math::circle_segment::CircleSegment;
+use crate::display::shape::primitive::system::ShapeSystem;
+use crate::display::symbol::geometry::Sprite;
+use crate::display::world::World;
 use crate::math::topology::unit::AngleOps;
-use crate::math::topology::unit::Distance;
-use crate::math::topology::unit::PixelDistance;
-use crate::math::topology::unit::Pixels;
 use crate::math::topology::unit::{Angle, Degrees};
-
-use nalgebra::Vector2;
-
+use crate::display::object::Node;
+use crate::display;
+use crate::display::object::Object;
+use nalgebra as na;
 
 
 // ===========================
@@ -24,7 +20,7 @@ use nalgebra::Vector2;
 
 /// Indicates whether a port is incoming or outgoing.
 #[derive(Clone,Copy,Debug,Eq,PartialEq)]
-pub enum PortDirection {
+pub enum Direction {
     /// Indicates port facing towards the center of its inner circle.
     Inwards,
     /// Indicates port facing away from the center of its inner circle.
@@ -39,7 +35,7 @@ pub enum PortDirection {
 /// most measurements are in degrees, which are measured around
 /// a inner circle, that is defined by the `inner_radius`.
 #[derive(Clone,Copy,Debug)]
-pub struct PortSpecification{
+pub struct Specification{
     /// Height of the port.
     pub height      : f32,
     /// Width of the port in degrees.
@@ -47,73 +43,99 @@ pub struct PortSpecification{
     /// Radius of the inner circle that the port is constructed around.
     pub inner_radius: f32,
     /// Direction the port is facing.
-    pub direction   : PortDirection,
+    pub direction   : Direction,
     /// Location of the port along the inner circle.
     pub location    : Angle<Degrees>,
     /// Fill colour of the port.
     pub color       : Srgb<f32>,
 }
 
+// ==================
+// === Port Shape ===
+// ==================
 
-// ============
-// === Port ===
-// =============
+mod shape{
+    use crate::display::shape::compound::port::{Specification, Direction};
+    use crate::display::shape::*;
+    use crate::display::shape::primitive::def::modifier::immutable::*;
+    use crate::display::shape::primitive::def::primitive::*;
+    use crate::prelude::*;
+    use crate::display::shape::primitive::def::class::ShapeOps;
+    use crate::math::circle_segment::CircleSegment;
+    use crate::math::topology::unit::AngleOps;
+    use crate::math::topology::unit::Distance;
+    use crate::math::topology::unit::PixelDistance;
+    use crate::math::topology::unit::Pixels;
+    use nalgebra as na;
 
-#[derive(Clone,Copy,Debug)]
-/// Dummy struct for port construction.
-pub struct Port;
-
-impl Port{
     /// Construct a port according to the given `PortSpecification`.
     #[allow(clippy::new_ret_no_self)]
-    pub fn new(spec:PortSpecification) -> AnyShape{
-        let show_debug = false;
+    pub fn make_shape(spec:Specification) -> (AnyShape, f32) {
         match spec.direction{
-            PortDirection::Inwards  => Port::new_port_inwards(spec, show_debug),
-            PortDirection::Outwards => Port::new_port_outwards(spec, show_debug),
-
+            Direction::Inwards  => new_port_inwards(spec),
+            Direction::Outwards => new_port_outwards(spec),
         }
     }
 
+
+// fn new_port_shape(spec:PortSpecification) -> AnyShape{
+//     let inner_radius = spec.inner_radius;
+//
+//     let segment = CircleSegment::new(inner_radius,spec.width.radians());
+//
+//
+//     let tri_height = spec.height;
+//     let tri_base = segment.chord_length();
+//     let tri_angle = Angle::from(FRAC_2_PI);
+//     let triangle = triangle::Triangle::from_sas(tri_height,tri_base,tri_angle);
+//     let angle = triangle.beta;
+//
+//     let plane_angle  = PlaneAngle(Angle::new((2.0 * PI) - (2.0 * angle.value)));
+//     let plane_angle = Rotation(plane_angle, 180.0.deg().radians());
+//
+//     let tri_top =  inner_radius + spec.height;
+//     let offset: Vector2<Distance<Pixels>> =  Vector2::new(Distance::new(0.0),Distance::new(tri_top));
+//     let plane_angle = Translate(plane_angle,offset);
+//
+//     let circle_inner = Circle(spec.inner_radius.px());
+//
+//     let triangle_rounded = Difference(plane_angle,circle_inner.clone()).fill(spec.color);
+//
+//     let debug_circle = circle_inner.fill(Srgba::new(0.1,0.1,0.1,0.5));
+//
+//     (triangle_rounded).into()
+// }
+
     /// Construct an outwards facing port.
-    fn new_port_outwards(spec:PortSpecification, show_debug:bool) -> AnyShape{
-        debug_assert_eq!(spec.direction,PortDirection::Outwards);
+    fn new_port_outwards(spec:Specification) -> (AnyShape, f32) {
+        debug_assert_eq!(spec.direction, Direction::Outwards);
 
         let inner_radius = spec.inner_radius;
-
         let segment = CircleSegment::new(inner_radius,spec.width.radians());
 
         // Create the triangle (pointing up)
-        let tri_base   = inner_radius - segment.sagitta();
+        let tri_base   = segment.sagitta();
         let tri_height = spec.height + segment.sagitta();
         let tri_width  = segment.chord_length();
 
         let triangle = Triangle(tri_width,tri_height);
 
-        // Move the triangle to its base position and rotate it to its final destination.
-        let offfset: Vector2<Distance<Pixels>> =  Vector2::new(Distance::new(0.0),Distance::new(tri_base));
-        let triangle = Translate(triangle,offfset);
-        let triangle = Rotation(triangle,spec.location.radians());
-
         let circle_inner = Circle(spec.inner_radius.px());
+        let circle_offset: na::Vector2<Distance<Pixels>> =  na::Vector2::new(Distance::new(0.0),Distance::new(segment.sagitta()-spec.inner_radius));
+        let circle_inner = Translate(circle_inner,circle_offset);
 
         let triangle_rounded = Difference(triangle,circle_inner.clone()).fill(spec.color);
+        let tri_offset: Vector2<Distance<Pixels>> =  Vector2::new(Distance::new(0.0),Distance::new(-tri_base));
+        let triangle_rounded = Translate(triangle_rounded,tri_offset);
 
-        if show_debug{
-            let debug_circle = circle_inner.fill(Srgba::new(0.1,0.1,0.1,0.5));
-            (triangle_rounded + debug_circle).into()
-        } else{
-            triangle_rounded.into()
-        }
-
+        (triangle_rounded.into(), 0.0)
     }
 
     /// Construct an inwards facing port.
-    fn new_port_inwards(spec:PortSpecification, show_debug:bool) -> AnyShape{
-        debug_assert_eq!(spec.direction,PortDirection::Inwards);
+    fn new_port_inwards(spec:Specification) -> (AnyShape, f32) {
+        debug_assert_eq!(spec.direction, Direction::Inwards);
 
         let outer_radius = spec.inner_radius + spec.height;
-
         let segment = CircleSegment::new(outer_radius,spec.width.radians());
 
         // Create the triangle (pointing up)
@@ -125,20 +147,90 @@ impl Port{
         let triangle = Rotation(triangle, 180.0.deg().radians());
 
         // Move the triangle to its base position and rotate it to its final destination.
-        let tri_base = outer_radius;
-        let offfset: Vector2<Distance<Pixels>> =  Vector2::new(Distance::new(0.0),Distance::new(tri_base));
+        let offfset: Vector2<Distance<Pixels>> =  Vector2::new(Distance::new(0.0),Distance::new(tri_height));
         let triangle = Translate(triangle,offfset);
-        let triangle = Rotation(triangle,spec.location.radians());
 
         let circle_outer = Circle(outer_radius.px());
-
+        let circle_offset: Vector2<Distance<Pixels>> =  Vector2::new(Distance::new(0.0),Distance::new(tri_height-outer_radius));
+        let circle_outer = Translate(circle_outer,circle_offset);
         let triangle_rounded = Intersection(triangle,circle_outer.clone()).fill(spec.color);
 
-        if show_debug{
-            let debug_circle = circle_outer.fill(Srgba::new(0.1,0.1,0.1, 0.5));
-            (triangle_rounded + debug_circle).into()
-        } else{
-            triangle_rounded.into()
-        }
+        (triangle_rounded.into(), 0.0)
+
+    }
+
+}
+
+//
+// struct BoundingBox{
+//     top: f32,
+//     left: f32,
+//     bottom: f32,
+//     right: f32,
+// }
+//
+// struct ShapeDescription{
+//     pub shape: AnyShape,
+//     pub pivot: Vector2<f32>,
+//     pub bbox: BoundingBox,
+//
+// }
+// =================
+// === Port Node ===
+// =================
+
+#[derive(Debug)]
+/// Dummy struct for port construction.
+pub struct Port {
+    spec         : Specification,
+    shape        : AnyShape,
+    shape_system : ShapeSystem,
+    sprite       : Sprite,
+    sprite_node  : Node,
+}
+
+impl Port {
+
+    pub fn new(spec:Specification, world:&World,parent:&Node) -> Self{
+        let (shape, _dh) = shape::make_shape(spec);
+        let shape_system = ShapeSystem::new(world,&shape);
+        let sprite = shape_system.new_instance();
+        sprite.size().set(na::Vector2::new(75.0,75.0));
+
+        let sprite_node = Node::new(Logger::new("node_sprite"));
+        parent.add_child(&sprite_node);
+
+        let port = Port{spec,shape,shape_system,sprite,sprite_node};
+        port.update_sprite_position_orientation();
+        port
+    }
+
+    pub fn update(&self) {
+        self.shape_system.display_object().update();
+        self.update_sprite_position_orientation();
+    }
+
+    /// Modifies the rotation of the sprite.
+    pub fn mod_specification<F:FnOnce(&mut Specification)>(&mut self, f:F) {
+        f(&mut self.spec);
+        self.update();
+    }
+
+    pub fn update_sprite_position_orientation(&self) {
+        let translation_vector = na::Vector3::new(0.0,self.spec.inner_radius,0.0);
+        let rotation_vector = -na::Vector3::new(0.0,0.0,self.spec.location.rad().value);
+        let rotation = na::Rotation3::new(rotation_vector.clone());
+        let translation = rotation * translation_vector;
+
+        self.sprite_node.set_position(translation);
+        self.sprite.set_position(dbg!(self.sprite_node.global_position()));
+        self.sprite.set_rotation(rotation_vector);
+    }
+
+}
+
+impl Into<display::object::Node> for &Port {
+    fn into(self) -> display::object::Node {
+        (&self.shape_system).into()
     }
 }

--- a/src/rust/ensogl/src/display/symbol/gpu/geometry/compound/sprite.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu/geometry/compound/sprite.rs
@@ -89,6 +89,16 @@ impl {
         self.display_object.set_position(value)
     }
 
+    /// Modifies the rotation of the sprite.
+    pub fn mod_rotation<F:FnOnce(&mut Vector3<f32>)>(&self, f:F) {
+        self.display_object.mod_rotation(f);
+    }
+
+    /// Sets the rotation of the sprite.
+    pub fn set_rotation(&self, value:Vector3<f32>) {
+        self.display_object.set_rotation(value)
+    }
+
     /// Position of the sprite.
     pub fn position(&self) -> Vector3<f32> {
         self.display_object.position()

--- a/src/rust/ensogl/src/math.rs
+++ b/src/rust/ensogl/src/math.rs
@@ -1,6 +1,7 @@
 //! Root module for math-related utilities.
 
 pub mod circle_segment;
+pub mod geometry;
 pub mod topology;
 pub mod types;
 

--- a/src/rust/ensogl/src/math.rs
+++ b/src/rust/ensogl/src/math.rs
@@ -1,5 +1,6 @@
 //! Root module for math-related utilities.
 
+pub mod circle_segment;
 pub mod topology;
 pub mod types;
 

--- a/src/rust/ensogl/src/math/circle_segment.rs
+++ b/src/rust/ensogl/src/math/circle_segment.rs
@@ -1,0 +1,55 @@
+//! Provides functionality related to circle segments.
+use crate::math::topology::unit::{Angle, Radians};
+
+
+
+// =====================
+// === CircleSegment ===
+// =====================
+
+/// Implements computations related to circle segments.
+/// For details and background on the formulas used, see
+/// https://en.wikipedia.org/wiki/Circular_segment
+#[derive(Clone,Copy,Debug,PartialEq)]
+pub struct CircleSegment{
+    radius: f32,
+    angle : Angle<Radians>,
+}
+
+impl CircleSegment{
+
+    /// Constructor.
+    pub fn new(radius:f32, angle:Angle<Radians>) -> Self{
+        CircleSegment{radius, angle}
+    }
+
+    /// The length of the direct line between the segment end points.
+    pub fn chord_length(self) -> f32{
+        let r     = self.radius;
+        let theta = self.angle.value;
+
+        2.0 * r * (theta * 0.5).sin()
+    }
+
+    /// The arc length of the circle segment.
+    pub fn arc_length(self) -> f32{
+        let r     = self.radius;
+        let theta = self.angle.value;
+
+        r * theta
+    }
+
+    /// The sagitta (height) of the segment.
+    pub fn sagitta(self) -> f32{
+        let r     = self.radius;
+        let theta = self.angle.value;
+
+        r * (1.0 - (theta * 0.5).cos())
+    }
+
+    /// The apothem (height) of the triangular portion.
+    pub fn apothem(self) -> f32{
+        self.radius - self.sagitta()
+    }
+
+}

--- a/src/rust/ensogl/src/math/geometry.rs
+++ b/src/rust/ensogl/src/math/geometry.rs
@@ -1,0 +1,1 @@
+pub mod triangle;

--- a/src/rust/ensogl/src/math/geometry/triangle.rs
+++ b/src/rust/ensogl/src/math/geometry/triangle.rs
@@ -1,0 +1,27 @@
+use crate::math::topology::unit::{Radians, Angle};
+use core::f32::consts::PI;
+
+pub struct Triangle {
+    pub a     : f32,
+    pub b     : f32,
+    pub c     : f32,
+    pub alpha : Angle<Radians>,
+    pub beta  : Angle<Radians>,
+    pub gamma : Angle<Radians>,
+}
+
+impl Triangle{
+    /// Two sides and the included angle given (SAS)
+    pub fn from_sas(a:f32, b:f32, gamma:Angle<Radians>) -> Triangle {
+        let c_squared = a.powi(2) + b.powi(2) - (2.0 * a * b * gamma.value.cos());
+        let c = c_squared.sqrt();
+
+        let alpha = (b.powi(2) + c.powi(2) - a.powi(2)) / (2.0 * b * c);
+        let alpha = Angle::new(alpha);
+
+        let beta = PI - alpha.value - gamma.value;
+        let beta = Angle::new(beta);
+
+        Triangle{a,b,c,alpha,beta,gamma}
+    }
+}

--- a/src/rust/ensogl/src/math/topology/unit.rs
+++ b/src/rust/ensogl/src/math/topology/unit.rs
@@ -261,6 +261,24 @@ impl AngleOps for i32 {
     }
 }
 
+impl AngleOps for Angle<Degrees> {
+    fn degrees(&self) -> Angle<Degrees> {
+        self.clone()
+    }
+
+    fn radians(&self) -> Angle<Radians> {
+        Angle::new(self.value.to_radians())
+    }
+}
+
+impl AngleOps for Angle<Radians> {
+    fn degrees(&self) -> Angle<Degrees> { Angle::new(self.value.to_degrees()) }
+
+    fn radians(&self) -> Angle<Radians> {
+        self.clone()
+    }
+}
+
 impls! { From< Angle<Radians>> for Glsl { |t| { iformat!("Radians({t.value.glsl()})").into() } }}
 impls! { From<&Angle<Radians>> for Glsl { |t| { iformat!("Radians({t.value.glsl()})").into() } }}
 impls! { From< Angle<Degrees>> for Glsl { |t| { iformat!("radians(Degrees({t.value.glsl()}))").into() } }}

--- a/src/rust/lib/debug-scenes/src/lib.rs
+++ b/src/rust/lib/debug-scenes/src/lib.rs
@@ -23,6 +23,7 @@ pub mod dom_symbols;
 pub mod easing_animator;
 pub mod glyph_system;
 pub mod ide;
+pub mod ports;
 pub mod shapes;
 pub mod sprite_system;
 pub mod text_field;

--- a/src/rust/lib/debug-scenes/src/ports.rs
+++ b/src/rust/lib/debug-scenes/src/ports.rs
@@ -1,0 +1,99 @@
+#![allow(missing_docs)]
+
+//! NOTE
+//! This file is under a heavy development. It contains commented lines of code and some code may
+//! be of poor quality. Expect drastic changes.
+
+use ensogl::traits::*;
+
+use ensogl::data::color::*;
+use ensogl::display::shape::*;
+use ensogl::display::shape::compound::port::{PortSpecification, Port, PortDirection};
+use ensogl::display::shape::primitive::system::ShapeSystem;
+use ensogl::display::symbol::geometry::Sprite;
+use ensogl::display::world::*;
+use ensogl::math::topology::unit::AngleOps;
+use ensogl::system::web;
+use nalgebra::Vector2;
+use wasm_bindgen::prelude::*;
+
+
+
+#[wasm_bindgen]
+#[allow(dead_code)]
+pub fn run_example_ports() {
+    web::forward_panic_hook_to_console();
+    web::set_stdout();
+    web::set_stack_trace_limit();
+    init(&WorldData::new(&web::get_html_element_by_id("root").unwrap()));
+}
+
+
+fn init(world: &World) {
+    let scene  = world.scene();
+    let camera = scene.camera();
+    let screen = camera.screen();
+
+    let port_spec = PortSpecification{
+        height: 30.0,
+        width: Angle::from(45.0),
+        inner_radius: 80.0,
+        direction: PortDirection::Outwards,
+        location: 90.0_f32.deg(),
+        color: Srgb::new(51.0 / 255.0, 102.0 / 255.0, 153.0 / 255.0 ),
+    };
+
+    let port_shape_1 = Port::new(port_spec);
+
+    let port_spec = PortSpecification{
+        height: 30.0,
+        width: Angle::from(45.0),
+        inner_radius: 80.0,
+        direction: PortDirection::Inwards,
+        location: 270.0_f32.deg(),
+        color: Srgb::new(51.0 / 255.0, 102.0 / 255.0, 153.0 / 255.0 ),
+    };
+
+    let port_shape_2 = Port::new(port_spec);
+
+    let shape_system =     ShapeSystem::new(world,&port_shape_1);
+    let sprite = shape_system.new_instance();
+    sprite.size().set(Vector2::new(500.0,500.0));
+    sprite.mod_position(|t| {
+        t.x += screen.width / 2.0;
+        t.y += screen.height / 2.0;
+    });
+
+    let shape_system_2 =     ShapeSystem::new(world,&port_shape_2);
+    let sprite_2 = shape_system_2.new_instance();
+    sprite_2.size().set(Vector2::new(500.0,500.0));
+    sprite_2.mod_position(|t| {
+        t.x += screen.width / 2.0;
+        t.y += screen.height / 2.0;
+    });
+
+
+    world.add_child(&shape_system);
+    world.add_child(&shape_system_2);
+
+    let mut iter:i32 = 0;
+    let mut time:i32 = 0;
+    world.on_frame(move |_| {
+        iter +=1;
+        on_frame(&mut time,&mut iter,&sprite,&shape_system);
+        on_frame(&mut time,&mut iter,&sprite_2,&shape_system_2);
+
+    }).forget();
+}
+
+
+#[allow(clippy::too_many_arguments)]
+#[allow(clippy::many_single_char_names)]
+pub fn on_frame
+( _time        : &mut i32
+  , _iter         : &mut i32
+  , sprite     : &Sprite
+  , shape_system : &ShapeSystem) {
+    sprite.mod_rotation(|r| r.z += 0.01);
+    shape_system.display_object().update();
+}

--- a/src/rust/lib/debug-scenes/src/ports.rs
+++ b/src/rust/lib/debug-scenes/src/ports.rs
@@ -5,10 +5,10 @@
 //! be of poor quality. Expect drastic changes.
 
 use ensogl::traits::*;
-
+use ensogl::prelude::*;
 use ensogl::data::color::*;
 use ensogl::display::shape::*;
-use ensogl::display::shape::compound::port::{PortSpecification, Port, PortDirection};
+use ensogl::display::shape::compound::port::{Specification, Port, Direction};
 use ensogl::display::shape::primitive::system::ShapeSystem;
 use ensogl::display::symbol::geometry::Sprite;
 use ensogl::display::world::*;
@@ -16,7 +16,8 @@ use ensogl::math::topology::unit::AngleOps;
 use ensogl::system::web;
 use nalgebra::Vector2;
 use wasm_bindgen::prelude::*;
-
+use ensogl::display::object::Node;
+use ensogl::display::object::Object;
 
 
 #[wasm_bindgen]
@@ -28,63 +29,87 @@ pub fn run_example_ports() {
     init(&WorldData::new(&web::get_html_element_by_id("root").unwrap()));
 }
 
+fn node(node_radius:f32, colour:Srgba<f32>) -> AnyShape {
+    let node   = Circle(node_radius.px());//    let border = Circle((node_radius + border_size).px());
+    let node   = node.fill(colour);
+    let out    = node;
+    out.into()
+}
 
 fn init(world: &World) {
     let scene  = world.scene();
     let camera = scene.camera();
     let screen = camera.screen();
 
-    let port_spec = PortSpecification{
-        height: 30.0,
-        width: Angle::from(45.0),
-        inner_radius: 80.0,
-        direction: PortDirection::Outwards,
+    let node_radius = 60.0 ;
+    let port_height = 30.0;
+
+    let parent_node = Node::new(Logger::new("parent"));
+    parent_node.mod_position(|t| {
+        t.x += screen.width / 2.0;
+        t.y += screen.height / 3.0;
+    });
+    parent_node.update();
+
+    let node_shape = node(node_radius, Srgba::new(0.57,0.56,0.55,0.5));
+    let node_shape_system =     ShapeSystem::new(world, &node_shape);
+    let node_sprite = node_shape_system.new_instance();
+    node_sprite.size().set(Vector2::new(200.0, 200.0));
+    node_sprite.set_position(parent_node.global_position());
+
+    let node2_shape = node(node_radius + port_height,Srgba::new(0.77,0.76,0.75,0.5));
+    let node2_shape_system =     ShapeSystem::new(world, &node2_shape);
+    let node2_sprite = node2_shape_system.new_instance();
+    node2_sprite.size().set(Vector2::new(200.0, 200.0));
+    node2_sprite.set_position(parent_node.global_position());
+
+    let port_spec = Specification{
+        height: port_height,
+        width: Angle::from(25.0),
+        inner_radius: node_radius,
+        direction: Direction::Outwards,
         location: 90.0_f32.deg(),
         color: Srgb::new(51.0 / 255.0, 102.0 / 255.0, 153.0 / 255.0 ),
     };
 
-    let port_shape_1 = Port::new(port_spec);
+    let mut port_1 = Port::new(port_spec, &world, &parent_node);
 
-    let port_spec = PortSpecification{
-        height: 30.0,
-        width: Angle::from(45.0),
-        inner_radius: 80.0,
-        direction: PortDirection::Inwards,
+    let port_spec = Specification{
+        height: port_height,
+        width: Angle::from(25.0),
+        inner_radius: node_radius,
+        direction: Direction::Inwards,
         location: 270.0_f32.deg(),
         color: Srgb::new(51.0 / 255.0, 102.0 / 255.0, 153.0 / 255.0 ),
     };
 
-    let port_shape_2 = Port::new(port_spec);
+    let mut port_2 = Port::new(port_spec, &world, &parent_node);
 
-    let shape_system =     ShapeSystem::new(world,&port_shape_1);
-    let sprite = shape_system.new_instance();
-    sprite.size().set(Vector2::new(500.0,500.0));
-    sprite.mod_position(|t| {
-        t.x += screen.width / 2.0;
-        t.y += screen.height / 2.0;
-    });
-
-    let shape_system_2 =     ShapeSystem::new(world,&port_shape_2);
-    let sprite_2 = shape_system_2.new_instance();
-    sprite_2.size().set(Vector2::new(500.0,500.0));
-    sprite_2.mod_position(|t| {
-        t.x += screen.width / 2.0;
-        t.y += screen.height / 2.0;
-    });
-
-
-    world.add_child(&shape_system);
-    world.add_child(&shape_system_2);
+    world.add_child(&port_1);
+    world.add_child(&port_2);
+    world.add_child(&node_shape_system);
+    world.add_child(&node2_shape_system);
 
     let mut iter:i32 = 0;
     let mut time:i32 = 0;
     world.on_frame(move |_| {
         iter +=1;
-        on_frame(&mut time,&mut iter,&sprite,&shape_system);
-        on_frame(&mut time,&mut iter,&sprite_2,&shape_system_2);
+        port_1.mod_specification(|s|{
+            s.location = Angle::from(s.location.value + 1.0);
+        });
+        port_2.mod_specification(|s|{
+            s.location = Angle::from(s.location.value + 1.0);
+        });
+
+        parent_node.update();
+        port_1.update();
+        port_2.update();
+        on_frame(&mut time,&mut iter,&node_sprite,&node_shape_system);
+        on_frame(&mut time,&mut iter,&node2_sprite,&node2_shape_system);
 
     }).forget();
 }
+
 
 
 #[allow(clippy::too_many_arguments)]
@@ -94,6 +119,6 @@ pub fn on_frame
   , _iter         : &mut i32
   , sprite     : &Sprite
   , shape_system : &ShapeSystem) {
-    sprite.mod_rotation(|r| r.z += 0.01);
+    // sprite.mod_rotation(|r| r.z += 0.01);
     shape_system.display_object().update();
 }


### PR DESCRIPTION
### Pull Request Description
Adds functionality to draw ports and some related utilities.
Related to #210  

### Important Notes
There is a demo scene that can be accessed on `http://localhost:8080/debug/ports`

This contains the first instance of a compound shape. We should evaluate whether the chosen API can be used as a template for others. 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

