### PR TITLE
#[derive(CloneRef)] also works on types with type-level bounds.

### DIFF
--- a/src/rust/lib/macro-utils/src/lib.rs
+++ b/src/rust/lib/macro-utils/src/lib.rs
@@ -240,29 +240,6 @@ pub fn variant_depends_on
 
 
 
-// ====================
-// === GenericParam ===
-// ====================
-
-/// Retrieves identifier from GenericParam. For example, from `T:Display` it returns `T`.
-/// For `'a: 'b + 'c` it gives `'a`.
-///
-/// This is useful e.g. when from generics information attached to a declaration of type we want to
-/// generate simplified
-pub fn generic_param_ident(param:&syn::GenericParam) -> TokenStream {
-    use quote::ToTokens;
-    match param {
-        syn::GenericParam::Type(type_param) =>
-            type_param.ident.to_token_stream(),
-        syn::GenericParam::Lifetime(lifetime) =>
-            lifetime.lifetime.to_token_stream(),
-        syn::GenericParam::Const(const_param) =>
-            const_param.ident.to_token_stream(),
-    }
-}
-
-
-
 // ===================
 // === WhereClause ===
 // ===================
@@ -369,17 +346,5 @@ mod tests {
         check(vec!["A", "B"], "Either<A,B>");
         assert_eq!(super::last_type_arg(&parse("i32")), None);
         assert_eq!(repr(&super::last_type_arg(&parse("Foo<C>"))), "C");
-    }
-
-    #[test]
-    fn generic_param_ident_test() {
-        fn check(param:&str, expected_ident:&str) {
-            let param = parse::<syn::GenericParam>(param);
-            let ident = generic_param_ident(&param);
-            assert_eq!(repr(&ident), expected_ident);
-        }
-        check("T:Clone", "T");
-        check("'a: 'b + 'c + 'd", "'a");
-        check("const LENGTH: usize", "LENGTH");
     }
 }

--- a/src/rust/lib/shapely/impl/tests/derive_clone_ref.rs
+++ b/src/rust/lib/shapely/impl/tests/derive_clone_ref.rs
@@ -36,3 +36,21 @@ struct StructUnnamedBound<T>(T);
 #[derive(CloneRef,Clone)]
 #[clone_ref(bound="T:CloneRef,U:CloneRef")]
 struct StructUnnamedBoundTwoPatams<T,U>(T,U);
+
+#[derive(Clone,CloneRef)]
+#[clone_ref(bound="T:Clone+Display")]
+struct StructBoundGeneric<T:Display>(Rc<T>);
+
+#[derive(CloneRef,Derivative)]
+#[derivative(Clone(bound=""))]
+// Note: CloneRef "knows" about `Display` bound.
+struct StructGenericLifetime<'t>(Rc<&'t String>);
+
+#[derive(CloneRef,Derivative)]
+#[derivative(Clone(bound=""))]
+struct StructWhereClause<T>(Rc<T>) where T:Debug;
+
+#[derive(CloneRef,Clone)]
+#[clone_ref(bound="T:CloneRef")]
+// Here derive macro must correctly merge user-provided bound, generics list bound and where clause.
+struct StructVariousBounds<T:Display>(T) where T:Debug;

--- a/src/rust/lib/shapely/impl/tests/derive_clone_ref.rs
+++ b/src/rust/lib/shapely/impl/tests/derive_clone_ref.rs
@@ -32,3 +32,7 @@ struct StructUnnamedUnbound<T>(Rc<T>);
 #[derive(CloneRef,Clone)]
 #[clone_ref(bound="T:CloneRef")]
 struct StructUnnamedBound<T>(T);
+
+#[derive(CloneRef,Clone)]
+#[clone_ref(bound="T:CloneRef,U:CloneRef")]
+struct StructUnnamedBoundTwoPatams<T,U>(T,U);

--- a/src/rust/lib/shapely/macros/src/derive_clone_ref.rs
+++ b/src/rust/lib/shapely/macros/src/derive_clone_ref.rs
@@ -195,7 +195,7 @@ pub fn derive
     };
     let bounds = decl.attrs.iter().filter_map(clone_ref_bounds).flatten();
     let output = quote!{
-        impl <#(#params)*> CloneRef for #ident<#(#params)*>
+        impl <#(#params),*> CloneRef for #ident<#(#params),*>
         where #(#bounds),* {
             fn clone_ref(&self) -> Self {
                 #body


### PR DESCRIPTION
### Pull Request Description
Fix for issue reported by @wdanilo  that macro deriving CloneRef fails when target type declaration has bounds on its generic parameters or a where clause.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

