### PR TITLE
Enable alpha blending for ID pass

### DIFF
--- a/src/rust/ensogl/src/display/render/composer.rs
+++ b/src/rust/ensogl/src/display/render/composer.rs
@@ -109,7 +109,8 @@ impl ComposerPass {
             let name    = format!("pass_{}",output.name());
             let args    = (self.width,self.height);
             let texture = uniform::get_or_add_gpu_texture_dyn
-                (&self.context,&self.variables,&name,output.internal_format,output.item_type,args);
+                (&self.context,&self.variables,&name,output.internal_format,output.item_type,args,
+                 Some(output.parameters));
             self.add_output(texture);
         }
     }

--- a/src/rust/ensogl/src/display/render/composer.rs
+++ b/src/rust/ensogl/src/display/render/composer.rs
@@ -110,7 +110,7 @@ impl ComposerPass {
             let args    = (self.width,self.height);
             let texture = uniform::get_or_add_gpu_texture_dyn
                 (&self.context,&self.variables,&name,output.internal_format,output.item_type,args,
-                 Some(output.parameters));
+                 Some(output.texture_parameters));
             self.add_output(texture);
         }
     }

--- a/src/rust/ensogl/src/display/render/passes/symbols.rs
+++ b/src/rust/ensogl/src/display/render/passes/symbols.rs
@@ -33,8 +33,8 @@ impl RenderPass for SymbolsRenderPass {
     fn outputs(&self) -> Vec<RenderPassOutput> {
         let color_parameters = texture::Parameters::default();
         let id_parameters = texture::Parameters{
-            min_filter: Context::NEAREST,
-            mag_filter: Context::NEAREST,
+            min_filter : Context::NEAREST,
+            mag_filter : Context::NEAREST,
             ..Default::default()
         };
         vec![ RenderPassOutput::new("color",texture::Rgba,texture::item_type::u8, color_parameters)

--- a/src/rust/ensogl/src/display/render/passes/symbols.rs
+++ b/src/rust/ensogl/src/display/render/passes/symbols.rs
@@ -33,8 +33,8 @@ impl RenderPass for SymbolsRenderPass {
     fn outputs(&self) -> Vec<RenderPassOutput> {
         let color_parameters = texture::Parameters::default();
         let id_parameters = texture::Parameters{
-            min_filter : Context::NEAREST,
-            mag_filter : Context::NEAREST,
+            min_filter : texture::MinFilterValue::NEAREST,
+            mag_filter : texture::MagFilterValue::NEAREST,
             ..Default::default()
         };
         vec![ RenderPassOutput::new("color",texture::Rgba,texture::item_type::u8, color_parameters)

--- a/src/rust/ensogl/src/display/render/passes/symbols.rs
+++ b/src/rust/ensogl/src/display/render/passes/symbols.rs
@@ -33,9 +33,9 @@ impl RenderPass for SymbolsRenderPass {
     fn outputs(&self) -> Vec<RenderPassOutput> {
         let color_parameters = texture::Parameters::default();
         let id_parameters    = texture::Parameters {
-            min_filter : texture::MinFilterValue::NEAREST,
-            mag_filter : texture::MagFilterValue::NEAREST,
-            ..Default::default()
+            min_filter : texture::MinFilter::NEAREST,
+            mag_filter : texture::MagFilter::NEAREST,
+            ..default()
         };
         vec![ RenderPassOutput::new("color",texture::Rgba,texture::item_type::u8,color_parameters)
             , RenderPassOutput::new("id",texture::Rgba,texture::item_type::u8,id_parameters)

--- a/src/rust/ensogl/src/display/render/passes/symbols.rs
+++ b/src/rust/ensogl/src/display/render/passes/symbols.rs
@@ -38,7 +38,7 @@ impl RenderPass for SymbolsRenderPass {
             ..Default::default()
         };
         vec![ RenderPassOutput::new("color",texture::Rgba,texture::item_type::u8,color_parameters)
-            , RenderPassOutput::new("id",texture::Rgba32f,texture::item_type::f32,id_parameters)
+            , RenderPassOutput::new("id",texture::Rgba,texture::item_type::u8,id_parameters)
             ]
     }
 

--- a/src/rust/ensogl/src/display/render/passes/symbols.rs
+++ b/src/rust/ensogl/src/display/render/passes/symbols.rs
@@ -32,15 +32,14 @@ impl SymbolsRenderPass {
 impl RenderPass for SymbolsRenderPass {
     fn outputs(&self) -> Vec<RenderPassOutput> {
         vec![ RenderPassOutput::new("color",texture::Rgba,texture::item_type::u8)
-            , RenderPassOutput::new("id",texture::Rgba32ui,texture::item_type::u32)
+            , RenderPassOutput::new("id",texture::Rgba32f,texture::item_type::f32)
             ]
     }
 
     fn run(&mut self, context:&Context, _:&UniformScope) {
         let arr = vec![0.0,0.0,0.0,0.0];
-        let arr2 = vec![0,0,0,0];
         context.clear_bufferfv_with_f32_array(Context::COLOR,0,&arr);
-        context.clear_bufferuiv_with_u32_array(Context::COLOR,1,&arr2);
+        context.clear_bufferfv_with_f32_array(Context::COLOR,1,&arr);
         self.target.set_camera(&self.views.main.camera);
         self.target.render_by_ids(&self.views.main.symbols());
     }

--- a/src/rust/ensogl/src/display/render/passes/symbols.rs
+++ b/src/rust/ensogl/src/display/render/passes/symbols.rs
@@ -32,13 +32,13 @@ impl SymbolsRenderPass {
 impl RenderPass for SymbolsRenderPass {
     fn outputs(&self) -> Vec<RenderPassOutput> {
         let color_parameters = texture::Parameters::default();
-        let id_parameters = texture::Parameters{
+        let id_parameters    = texture::Parameters {
             min_filter : texture::MinFilterValue::NEAREST,
             mag_filter : texture::MagFilterValue::NEAREST,
             ..Default::default()
         };
-        vec![ RenderPassOutput::new("color",texture::Rgba,texture::item_type::u8, color_parameters)
-            , RenderPassOutput::new("id",texture::Rgba32f,texture::item_type::f32, id_parameters)
+        vec![ RenderPassOutput::new("color",texture::Rgba,texture::item_type::u8,color_parameters)
+            , RenderPassOutput::new("id",texture::Rgba32f,texture::item_type::f32,id_parameters)
             ]
     }
 

--- a/src/rust/ensogl/src/display/render/passes/symbols.rs
+++ b/src/rust/ensogl/src/display/render/passes/symbols.rs
@@ -31,8 +31,14 @@ impl SymbolsRenderPass {
 
 impl RenderPass for SymbolsRenderPass {
     fn outputs(&self) -> Vec<RenderPassOutput> {
-        vec![ RenderPassOutput::new("color",texture::Rgba,texture::item_type::u8)
-            , RenderPassOutput::new("id",texture::Rgba32f,texture::item_type::f32)
+        let color_parameters = texture::Parameters::default();
+        let id_parameters = texture::Parameters{
+            min_filter: Context::NEAREST,
+            mag_filter: Context::NEAREST,
+            ..Default::default()
+        };
+        vec![ RenderPassOutput::new("color",texture::Rgba,texture::item_type::u8, color_parameters)
+            , RenderPassOutput::new("id",texture::Rgba32f,texture::item_type::f32, id_parameters)
             ]
     }
 

--- a/src/rust/ensogl/src/display/render/passes/symbols.rs
+++ b/src/rust/ensogl/src/display/render/passes/symbols.rs
@@ -33,8 +33,8 @@ impl RenderPass for SymbolsRenderPass {
     fn outputs(&self) -> Vec<RenderPassOutput> {
         let color_parameters = texture::Parameters::default();
         let id_parameters    = texture::Parameters {
-            min_filter : texture::MinFilter::NEAREST,
-            mag_filter : texture::MagFilter::NEAREST,
+            min_filter : texture::MinFilter::Nearest,
+            mag_filter : texture::MagFilter::Nearest,
             ..default()
         };
         vec![ RenderPassOutput::new("color",texture::Rgba,texture::item_type::u8,color_parameters)

--- a/src/rust/ensogl/src/display/render/pipeline.rs
+++ b/src/rust/ensogl/src/display/render/pipeline.rs
@@ -57,17 +57,17 @@ pub struct RenderPassOutput {
     /// Item texture type of the pass framebuffer's attachment.
     pub item_type : AnyItemType,
     /// Texture parameters that will be set when binding the texture.
-    pub parameters: Parameters,
+    pub texture_parameters : Parameters,
 }
 
 impl RenderPassOutput {
     /// Constructor.
     pub fn new<Name:Str,F:Into<AnyInternalFormat>,T:Into<AnyItemType>>
-    (name:Name, internal_format:F, item_type:T, parameters:Parameters) -> Self {
+    (name:Name, internal_format:F, item_type:T, texture_parameters:Parameters) -> Self {
         let name            = name.into();
         let internal_format = internal_format.into();
         let item_type       = item_type.into();
-        Self {name,internal_format,item_type,parameters}
+        Self {name,internal_format,item_type, texture_parameters }
     }
 
     /// Getter.

--- a/src/rust/ensogl/src/display/render/pipeline.rs
+++ b/src/rust/ensogl/src/display/render/pipeline.rs
@@ -3,7 +3,7 @@
 use crate::prelude::*;
 
 use crate::system::gpu::types::*;
-use crate::system::gpu::texture::*;
+use crate::system::gpu::texture;
 
 
 
@@ -53,17 +53,17 @@ pub struct RenderPassOutput {
     /// Name of the pass.
     pub name : String,
     /// Internal texture format of the pass framebuffer's attachment.
-    pub internal_format : AnyInternalFormat,
+    pub internal_format : texture::AnyInternalFormat,
     /// Item texture type of the pass framebuffer's attachment.
-    pub item_type : AnyItemType,
+    pub item_type : texture::AnyItemType,
     /// Texture parameters that will be set when binding the texture.
-    pub texture_parameters : Parameters,
+    pub texture_parameters : texture::Parameters,
 }
 
 impl RenderPassOutput {
     /// Constructor.
-    pub fn new<Name:Str,F:Into<AnyInternalFormat>,T:Into<AnyItemType>>
-    (name:Name, internal_format:F, item_type:T, texture_parameters:Parameters) -> Self {
+    pub fn new<Name:Str,F:Into<texture::AnyInternalFormat>,T:Into<texture::AnyItemType>>
+    (name:Name, internal_format:F, item_type:T, texture_parameters:texture::Parameters) -> Self {
         let name            = name.into();
         let internal_format = internal_format.into();
         let item_type       = item_type.into();

--- a/src/rust/ensogl/src/display/render/pipeline.rs
+++ b/src/rust/ensogl/src/display/render/pipeline.rs
@@ -56,16 +56,18 @@ pub struct RenderPassOutput {
     pub internal_format : AnyInternalFormat,
     /// Item texture type of the pass framebuffer's attachment.
     pub item_type : AnyItemType,
+    /// Texture parameters that will be set when binding the texture.
+    pub parameters: Parameters,
 }
 
 impl RenderPassOutput {
     /// Constructor.
     pub fn new<Name:Str,F:Into<AnyInternalFormat>,T:Into<AnyItemType>>
-    (name:Name, internal_format:F, item_type:T) -> Self {
+    (name:Name, internal_format:F, item_type:T, parameters:Parameters) -> Self {
         let name            = name.into();
         let internal_format = internal_format.into();
         let item_type       = item_type.into();
-        Self {name,internal_format,item_type}
+        Self {name,internal_format,item_type,parameters}
     }
 
     /// Getter.

--- a/src/rust/ensogl/src/display/render/pipeline.rs
+++ b/src/rust/ensogl/src/display/render/pipeline.rs
@@ -67,7 +67,7 @@ impl RenderPassOutput {
         let name            = name.into();
         let internal_format = internal_format.into();
         let item_type       = item_type.into();
-        Self {name,internal_format,item_type, texture_parameters }
+        Self {name,internal_format,item_type,texture_parameters}
     }
 
     /// Getter.

--- a/src/rust/ensogl/src/display/scene.rs
+++ b/src/rust/ensogl/src/display/scene.rs
@@ -123,20 +123,19 @@ impl Target {
     fn to_internal(&self) -> Vector4<u32> {
         match self {
             Self::Background                     => Vector4::new(0,0,0,0),
-            Self::Symbol {symbol_id,instance_id} => Vector4::new(*symbol_id,*instance_id,0,1),
+            Self::Symbol {symbol_id,instance_id} => {
+                Vector4::new(*symbol_id,*instance_id / 255,*instance_id % 255,1)
+            },
         }
     }
 
     fn from_internal(v:Vector4<u32>) -> Self {
-        if v.z != 0 {
-            panic!("Wrong internal format for mouse target.")
-        }
         if v.w == 0 {
             Self::Background
         }
-        else if v.w == 1 {
-            let symbol_id   = v.x;
-            let instance_id = v.y;
+        else if v.w == 255 {
+            let symbol_id   = v.x ;
+            let instance_id = v.y * 255 + v.z;
             Self::Symbol {symbol_id,instance_id}
         } else {
             panic!("Wrong internal format alpha for mouse target.")

--- a/src/rust/ensogl/src/display/scene.rs
+++ b/src/rust/ensogl/src/display/scene.rs
@@ -124,7 +124,7 @@ impl Target {
     /// Decode the symbol_id and instance_id that was encoded in the `fragment_runner`.
     ///
     /// See the `encode` method for more information on the encoding.
-    fn decode(pack1:u32, pack2:u32, pack3:u32) -> (u32, u32){
+    fn decode(pack1:u32, pack2:u32, pack3:u32) -> (u32, u32) {
         let value1 = (pack1 << 4) + (pack2 >> 4);
         let value2 = pack3 + ((pack2 & 0x00FF) << 8);
         (value1, value2)
@@ -134,24 +134,21 @@ impl Target {
     /// This is the same encoding that is used in the `fragment_runner`.
     /// This encoding is lossy.
     ///
-    /// Encodes the two values with 12 bit precision into 3 bytes.
-    /// If the values each contain more than 12 bit of information, that
-    /// information is lost.
-    ///
     ///  Input
     ///
-    ///   value1 as bytes                   value2 as bytes
+    ///   value1 as bytes                        value2 as bytes
     ///  ------------------------            ------------------------
     /// | v1a | v1b | v1c | v1d |           | v2a | v2b | v2c | v2d |
     /// -------------------------           -------------------------
-    /// Output
+    ///
+    ///  Output
     ///
     ///   byte1             byte2                byte3
     ///  ------     ----------------------      ------
     /// | v1d |    | v1c[4..8] v2c[4..8] |     | v2d |
     /// ------     -----------------------     ------
     ///
-    fn encode(value1: u32, value2: u32) -> (u8, u8, u8){
+    fn encode(value1:u32, value2:u32) -> (u8,u8,u8) {
         let pack1 = (value1 >> 4u32) & 0x00FFu32;
         let pack2 = (value1 & 0x00FFu32) << 4u32;
         let pack2 = pack2 | ((value2 & 0x0F00u32) >> 8u32);
@@ -174,10 +171,10 @@ impl Target {
             Self::Background
         }
         else if v.w == 255 {
-            let decoded     = Self::decode(v.x, v.y, v.z);
+            let decoded     = Self::decode(v.x,v.y,v.z);
             let symbol_id   = decoded.0;
             let instance_id = decoded.1;
-            Self::Symbol { symbol_id, instance_id }
+            Self::Symbol {symbol_id,instance_id}
         } else {
             panic!("Wrong internal format alpha for mouse target.")
         }
@@ -197,19 +194,19 @@ impl Default for Target {
 mod target_tests {
     use super::*;
 
-    fn assert_valid_roundtrip(value1: u32, value2: u32){
-        let pack   = Target::encode(value1, value2);
-        let unpack = Target::decode(pack.0 as u32, pack.1 as u32, pack.2 as u32);
-        assert_eq!(unpack.0, value1);
-        assert_eq!(unpack.1, value2);
+    fn assert_valid_roundtrip(value1:u32, value2:u32) {
+        let pack   = Target::encode(value1,value2);
+        let unpack = Target::decode(pack.0 as u32,pack.1 as u32,pack.2 as u32);
+        assert_eq!(unpack.0,value1);
+        assert_eq!(unpack.1,value2);
     }
 
     #[test]
     fn test_roundtrip_coding() {
-        assert_valid_roundtrip(   0,  0);
-        assert_valid_roundtrip(   0,  5);
-        assert_valid_roundtrip(512,  0);
-        assert_valid_roundtrip(1024, 64);
+        assert_valid_roundtrip(   0,   0);
+        assert_valid_roundtrip(   0,   5);
+        assert_valid_roundtrip( 512,   0);
+        assert_valid_roundtrip(1024,  64);
         assert_valid_roundtrip(1024, 999);
     }
 }

--- a/src/rust/ensogl/src/display/scene.rs
+++ b/src/rust/ensogl/src/display/scene.rs
@@ -121,21 +121,12 @@ pub enum Target {
 
 impl Target {
 
-    /// Decode the symbol_id and instance_id that was encoded in the `fragment_runner`.
-    ///
-    /// See the `encode` method for more information on the encoding.
-    fn decode(pack1:u32, pack2:u32, pack3:u32) -> (u32,u32) {
-        let value1 = (pack1 << 4) + (pack2 >> 4);
-        let value2 = pack3 + ((pack2 & 0x000F) << 8);
-        (value1, value2)
-    }
-
     /// Encode two u32 values into three u8 values.
-    /// This is the same encoding that is used in the `fragment_runner`.
-    /// This encoding is lossy.
     ///
-    /// We use 12 bits from each value and pack them into the 3 output bites like
-    /// described in the following diagram.
+    /// This is the same encoding that is used in the `fragment_runner`. This encoding is lossy.
+    ///
+    /// We use 12 bits from each value and pack them into the 3 output bytes like described in the
+    /// following diagram.
     ///
     ///  Input
     ///
@@ -152,11 +143,20 @@ impl Target {
     /// -----------------------    -----------------------     -------
     ///
     fn encode(value1:u32, value2:u32) -> (u8,u8,u8) {
-        let pack1 = (value1 >> 4u32) & 0x00FFu32;
-        let pack2 = (value1 & 0x000Fu32) << 4u32;
-        let pack2 = pack2 | ((value2 & 0x0F00u32) >> 8u32);
-        let pack3 = value2 & 0x00FFu32;
-        (pack1 as u8, pack2 as u8 , pack3 as u8)
+        let chunk1 = (value1 >> 4u32) & 0x00FFu32;
+        let chunk2 = (value1 & 0x000Fu32) << 4u32;
+        let chunk2 = chunk2 | ((value2 & 0x0F00u32) >> 8u32);
+        let chunk3 = value2 & 0x00FFu32;
+        (chunk1 as u8, chunk2 as u8, chunk3 as u8)
+    }
+
+    /// Decode the symbol_id and instance_id that was encoded in the `fragment_runner`.
+    ///
+    /// See the `encode` method for more information on the encoding.
+    fn decode(chunk1:u32, chunk2:u32, chunk3:u32) -> (u32, u32) {
+        let value1 = (chunk1 << 4) + (chunk2 >> 4);
+        let value2 = chunk3 + ((chunk2 & 0x000F) << 8);
+        (value1, value2)
     }
 
     fn to_internal(&self) -> Vector4<u32> {

--- a/src/rust/ensogl/src/display/scene.rs
+++ b/src/rust/ensogl/src/display/scene.rs
@@ -123,7 +123,8 @@ impl Target {
 
     /// Encode two u32 values into three u8 values.
     ///
-    /// This is the same encoding that is used in the `fragment_runner`. This encoding is lossy.
+    /// This is the same encoding that is used in the `fragment_runner`. This encoding is lossy and
+    /// can only encode values up to 12^2=4096 each
     ///
     /// We use 12 bits from each value and pack them into the 3 output bytes like described in the
     /// following diagram.

--- a/src/rust/ensogl/src/display/scene.rs
+++ b/src/rust/ensogl/src/display/scene.rs
@@ -130,23 +130,26 @@ impl Target {
         (value1, value2)
     }
 
-    /// Encode two u32 bit values into three u8 values.
+    /// Encode two u32 values into three u8 values.
     /// This is the same encoding that is used in the `fragment_runner`.
     /// This encoding is lossy.
     ///
+    /// We use 12 bits from each value and pack them into the 3 output bites like
+    /// described in the following diagram.
+    ///
     ///  Input
     ///
-    ///   value1 as bytes                        value2 as bytes
-    ///  ------------------------            ------------------------
+    ///  value1 as bytes                    value2 as bytes
+    /// -------------------------           -------------------------
     /// | v1a | v1b | v1c | v1d |           | v2a | v2b | v2c | v2d |
     /// -------------------------           -------------------------
     ///
     ///  Output
     ///
-    ///   byte1             byte2                byte3
-    ///  ------     ----------------------      ------
+    ///  byte1             byte2                byte3
+    /// -------    -----------------------     -------
     /// | v1d |    | v1c[4..8] v2c[4..8] |     | v2d |
-    /// ------     -----------------------     ------
+    /// -------    -----------------------     -------
     ///
     fn encode(value1:u32, value2:u32) -> (u8,u8,u8) {
         let pack1 = (value1 >> 4u32) & 0x00FFu32;
@@ -160,8 +163,8 @@ impl Target {
         match self {
             Self::Background                     => Vector4::new(0,0,0,0),
             Self::Symbol {symbol_id,instance_id} => {
-                let pack = Self::encode(*symbol_id, *instance_id);
-                Vector4::new(pack.0 as u32,pack.1 as u32,pack.2 as u32,1)
+                let pack = Self::encode(*symbol_id,*instance_id);
+                Vector4::new(pack.0.into(),pack.1.into(),pack.2.into(),1)
             },
         }
     }
@@ -196,7 +199,7 @@ mod target_tests {
 
     fn assert_valid_roundtrip(value1:u32, value2:u32) {
         let pack   = Target::encode(value1,value2);
-        let unpack = Target::decode(pack.0 as u32,pack.1 as u32,pack.2 as u32);
+        let unpack = Target::decode(pack.0.into(),pack.1.into(),pack.2.into());
         assert_eq!(unpack.0,value1);
         assert_eq!(unpack.1,value2);
     }

--- a/src/rust/ensogl/src/display/scene.rs
+++ b/src/rust/ensogl/src/display/scene.rs
@@ -124,7 +124,7 @@ impl Target {
     /// Decode the symbol_id and instance_id that was encoded in the `fragment_runner`.
     ///
     /// See the `encode` method for more information on the encoding.
-    fn decode(pack1:u32, pack2:u32, pack3:u32) -> (u32, u32) {
+    fn decode(pack1:u32, pack2:u32, pack3:u32) -> (u32,u32) {
         let value1 = (pack1 << 4) + (pack2 >> 4);
         let value2 = pack3 + ((pack2 & 0x00FF) << 8);
         (value1, value2)

--- a/src/rust/ensogl/src/display/scene.rs
+++ b/src/rust/ensogl/src/display/scene.rs
@@ -128,19 +128,22 @@ impl Target {
     /// We use 12 bits from each value and pack them into the 3 output bytes like described in the
     /// following diagram.
     ///
+    ///
     ///  Input
     ///
-    ///  value1 as bytes                    value2 as bytes
-    /// -------------------------           -------------------------
-    /// | v1a | v1b | v1c | v1d |           | v2a | v2b | v2c | v2d |
-    /// -------------------------           -------------------------
+    ///    value1 (v1) as bytes               value2 (v2) as bytes
+    ///   +-----+-----+-----+-----+           +-----+-----+-----+-----+
+    ///   |     |     |     |     |           |     |     |     |     |
+    ///   +-----+-----+-----+-----+           +-----+-----+-----+-----+
+    /// 32    24    16     8      0         32    24    16     8      0   <- Bit index
     ///
-    ///  Output
     ///
-    /// byte1                      byte2                      byte3
-    /// -----------------------    -----------------------     -------
-    /// | v2c[4..8] v1d[0..4] |    | v1d[4..8] v2c[4..8] |     | v2d |
-    /// -----------------------    -----------------------     -------
+    /// Output
+    ///
+    /// byte1            byte2                     byte3
+    /// +-----------+    +-------------------+     +-----------+
+    /// | v1[12..4] |    | v1[4..0] v2[4..0] |     | v2[12..4] |
+    /// +-----------+    +-------------------+     +-----------+
     ///
     fn encode(value1:u32, value2:u32) -> (u8,u8,u8) {
         let chunk1 = (value1 >> 4u32) & 0x00FFu32;
@@ -197,6 +200,9 @@ impl Default for Target {
 mod target_tests {
     use super::*;
 
+
+    /// Asserts that decoding encoded the given values returns the correct initial values again.
+    /// That means that `decode(encode(value1,value2)) == (value1,value2)`.
     fn assert_valid_roundtrip(value1:u32, value2:u32) {
         let pack   = Target::encode(value1,value2);
         let unpack = Target::decode(pack.0.into(),pack.1.into(),pack.2.into());

--- a/src/rust/ensogl/src/display/shape/primitive/glsl/fragment_runner.glsl
+++ b/src/rust/ensogl/src/display/shape/primitive/glsl/fragment_runner.glsl
@@ -11,7 +11,6 @@ output_id.r *= alpha_no_aa;
 output_id.g *= alpha_no_aa;
 output_id.b *= alpha_no_aa;
 
-
 if (input_display_mode == 0) {
     output_color = srgba(unpremultiply(shape.color)).raw;
     output_color.rgb *= alpha;

--- a/src/rust/ensogl/src/display/shape/primitive/glsl/fragment_runner.glsl
+++ b/src/rust/ensogl/src/display/shape/primitive/glsl/fragment_runner.glsl
@@ -4,12 +4,30 @@ Env   env        = Env(1);
 vec2  position   = input_local.xy ;
 Shape shape      = run(env,position);
 float alpha      = shape.color.color.raw.a;
+
+
+
+// ==============-------------
+// === Object ID Rendering ===
+// ==============-------------
+
+// This encoding needs to correspond to the decoding in the `Target` struct in
+// src\rust\ensogl\src\display\scene.rs
+uint instance_id_high = uint(input_instance_id) / uint(255);
+uint instance_id_low  = uint(input_instance_id) % uint(255);
+
 float alpha_no_aa = alpha > 0.5 ? 1.0 : 0.0;
 
-output_id = vec4(float(input_symbol_id),float(input_instance_id),0,alpha_no_aa);
+output_id = vec4(float(input_symbol_id) / 255.0, float(instance_id_high) / 255.0, float(instance_id_low) / 255.0, alpha_no_aa);
 output_id.r *= alpha_no_aa;
 output_id.g *= alpha_no_aa;
 output_id.b *= alpha_no_aa;
+
+
+
+// ==========-------------
+// === Color Rendering ===
+// ==========-------------
 
 if (input_display_mode == 0) {
     output_color = srgba(unpremultiply(shape.color)).raw;

--- a/src/rust/ensogl/src/display/shape/primitive/glsl/fragment_runner.glsl
+++ b/src/rust/ensogl/src/display/shape/primitive/glsl/fragment_runner.glsl
@@ -11,17 +11,11 @@ float alpha      = shape.color.color.raw.a;
 // === Object ID Rendering ===
 // ===========================
 
-// This encoding needs to correspond to the decoding in the `Target` struct in
-// src\rust\ensogl\src\display\scene.rs
-// See there for more explanation.
-uint pack1 = (uint(input_symbol_id) >> 4u) & 0x00FFu;
-uint pack2 = (uint(input_symbol_id) & 0x000Fu) << 4u;
-     pack2 = pack2 + ((uint(input_instance_id) & 0x0F00u) >> 8u);
-uint pack3 = uint(input_instance_id) & 0x00FFu;
+uvec3 chunks = encode(input_symbol_id,input_instance_id);
 
 float alpha_no_aa = alpha > 0.5 ? 1.0 : 0.0;
 
-output_id = vec4(float(pack1) / 255.0, float(pack2) / 255.0, float(pack3) / 255.0, alpha_no_aa);
+output_id = vec4(as_float_u8(chunks.x),as_float_u8(chunks.y),as_float_u8(chunks.z),alpha_no_aa);
 output_id.r *= alpha_no_aa;
 output_id.g *= alpha_no_aa;
 output_id.b *= alpha_no_aa;

--- a/src/rust/ensogl/src/display/shape/primitive/glsl/fragment_runner.glsl
+++ b/src/rust/ensogl/src/display/shape/primitive/glsl/fragment_runner.glsl
@@ -13,12 +13,15 @@ float alpha      = shape.color.color.raw.a;
 
 // This encoding needs to correspond to the decoding in the `Target` struct in
 // src\rust\ensogl\src\display\scene.rs
-uint instance_id_high = uint(input_instance_id) / uint(255);
-uint instance_id_low  = uint(input_instance_id) % uint(255);
+// See there for more explanation.
+uint pack1 = (uint(input_symbol_id) >> 4u) & 0x00FFu;
+uint pack2 = (uint(input_symbol_id) & 0x000Fu) << 4u;
+     pack2 = pack2 + ((uint(input_instance_id) & 0x0F00u) >> 8u);
+uint pack3 = uint(input_instance_id) & 0x00FFu;
 
 float alpha_no_aa = alpha > 0.5 ? 1.0 : 0.0;
 
-output_id = vec4(float(input_symbol_id) / 255.0, float(instance_id_high) / 255.0, float(instance_id_low) / 255.0, alpha_no_aa);
+output_id = vec4(float(pack1) / 255.0, float(pack2) / 255.0, float(pack3) / 255.0, alpha_no_aa);
 output_id.r *= alpha_no_aa;
 output_id.g *= alpha_no_aa;
 output_id.b *= alpha_no_aa;

--- a/src/rust/ensogl/src/display/shape/primitive/glsl/fragment_runner.glsl
+++ b/src/rust/ensogl/src/display/shape/primitive/glsl/fragment_runner.glsl
@@ -7,9 +7,9 @@ float alpha      = shape.color.color.raw.a;
 
 
 
-// ==============-------------
+// ===========================
 // === Object ID Rendering ===
-// ==============-------------
+// ===========================
 
 // This encoding needs to correspond to the decoding in the `Target` struct in
 // src\rust\ensogl\src\display\scene.rs
@@ -28,9 +28,9 @@ output_id.b *= alpha_no_aa;
 
 
 
-// ==========-------------
+// =======================
 // === Color Rendering ===
-// ==========-------------
+// =======================
 
 if (input_display_mode == 0) {
     output_color = srgba(unpremultiply(shape.color)).raw;

--- a/src/rust/ensogl/src/display/shape/primitive/glsl/fragment_runner.glsl
+++ b/src/rust/ensogl/src/display/shape/primitive/glsl/fragment_runner.glsl
@@ -4,12 +4,13 @@ Env   env        = Env(1);
 vec2  position   = input_local.xy ;
 Shape shape      = run(env,position);
 float alpha      = shape.color.color.raw.a;
-uint alpha_no_aa = alpha > 0.5 ? uint(1) : uint(0);
+float alpha_no_aa = alpha > 0.5 ? 1.0 : 0.0;
 
-output_id = uvec4(input_symbol_id,input_instance_id,0,alpha_no_aa);
+output_id = vec4(float(input_symbol_id),float(input_instance_id),0,alpha_no_aa);
 output_id.r *= alpha_no_aa;
 output_id.g *= alpha_no_aa;
 output_id.b *= alpha_no_aa;
+
 
 if (input_display_mode == 0) {
     output_color = srgba(unpremultiply(shape.color)).raw;

--- a/src/rust/ensogl/src/display/shape/primitive/glsl/math.glsl
+++ b/src/rust/ensogl/src/display/shape/primitive/glsl/math.glsl
@@ -178,3 +178,22 @@ float mul(float a, float b) {
 float neg(float a) {
     return -a;
 }
+
+
+// === Encode ===
+
+// This encoding must correspond to the decoding in the `Target` struct in
+// src\rust\ensogl\src\display\scene.rs See there for more explanation.
+uvec3 encode(int value1, int value2) {
+    uint chunk1 = (uint(value1) >> 4u) & 0x00FFu;
+    uint chunk2 = (uint(value1) & 0x000Fu) << 4u;
+    chunk2 = chunk2 + ((uint(value2) & 0x0F00u) >> 8u);
+    uint chunk3 = uint(value2) & 0x00FFu;
+    return uvec3(chunk1,chunk2,chunk3);
+}
+
+// Encodes a uint values so it can be stored in a u8 encoded float. Will clamp values that are
+// out of range.
+float as_float_u8(uint value) {
+    return clamp(float(value) / 255.0);
+}

--- a/src/rust/ensogl/src/display/shape/primitive/system.rs
+++ b/src/rust/ensogl/src/display/shape/primitive/system.rs
@@ -58,7 +58,7 @@ impl ShapeSystem {
         material.add_input  ("time"         , 0.0);
         material.add_input  ("symbol_id"    , 0);
         material.add_input  ("display_mode" , 0);
-        material.add_output ("id"           , Vector4::<f32>::new(0.0,0.0,0.0,0.0));
+        material.add_output ("id"           , Vector4::<f32>::zero());
         material
     }
 

--- a/src/rust/ensogl/src/display/shape/primitive/system.rs
+++ b/src/rust/ensogl/src/display/shape/primitive/system.rs
@@ -58,7 +58,7 @@ impl ShapeSystem {
         material.add_input  ("time"         , 0.0);
         material.add_input  ("symbol_id"    , 0);
         material.add_input  ("display_mode" , 0);
-        material.add_output ("id"           , Vector4::<u32>::new(0,0,0,0));
+        material.add_output ("id"           , Vector4::<f32>::new(0.0,0.0,0.0,0.0));
         material
     }
 

--- a/src/rust/ensogl/src/display/shape/text/glyph/system.rs
+++ b/src/rust/ensogl/src/display/shape/text/glyph/system.rs
@@ -258,7 +258,7 @@ impl GlyphSystem {
         // FIXME outputs as the number of attachments to framebuffer. We should manage this more
         // FIXME intelligent. For example, we could allow defining output shader fragments,
         // FIXME which will be enabled only if pass of given attachment type was enabled.
-        material.add_output("id", Vector4::<u32>::new(0,0,0,0));
+        material.add_output("id", Vector4::<f32>::new(0.0,0.0,0.0,0.0));
 
         let code = CodeTemplate::new(BEFORE_MAIN.to_string(),MAIN.to_string(),"".to_string());
         material.set_code(code);

--- a/src/rust/ensogl/src/display/symbol/gpu.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu.rs
@@ -334,13 +334,11 @@ impl Symbol {
                 return;
             }
             self.with_program(|_|{
-
                 for binding in &self.bindings.borrow().uniforms {
                     binding.upload(&self.context);
                 }
 
                 let context              = &self.context;
-
                 let textures             = &self.bindings.borrow().textures;
                 let bound_textures_iter  = textures.iter().map(|t| {t.bind_texture_unit(context)});
                 let _textures_keep_alive = bound_textures_iter.collect_vec();

--- a/src/rust/ensogl/src/display/symbol/gpu.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu.rs
@@ -341,10 +341,6 @@ impl Symbol {
 
                 let context              = &self.context;
 
-                context
-                .get_extension("EXT_color_buffer_float")
-                .expect("Could not get WebGL extension EXT_color_buffer_float");
-
                 let textures             = &self.bindings.borrow().textures;
                 let bound_textures_iter  = textures.iter().map(|t| {t.bind_texture_unit(context)});
                 let _textures_keep_alive = bound_textures_iter.collect_vec();
@@ -354,7 +350,11 @@ impl Symbol {
                 let count          = self.surface.point_scope().size()    as i32;
                 let instance_count = self.surface.instance_scope().size() as i32;
 
-                // println!("{:?}", self.context.check_framebuffer_status(Context::FRAMEBUFFER));
+                debug_assert_eq!(
+                    self.context.check_framebuffer_status(Context::FRAMEBUFFER),
+                    Context::FRAMEBUFFER_COMPLETE
+                );
+
                 self.stats.inc_draw_call_count();
                 if instance_count > 0 {
                     self.context.draw_arrays_instanced(mode,first,count,instance_count);

--- a/src/rust/ensogl/src/display/symbol/gpu.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu.rs
@@ -348,11 +348,17 @@ impl Symbol {
                 let count          = self.surface.point_scope().size()    as i32;
                 let instance_count = self.surface.instance_scope().size() as i32;
 
-                debug_assert_eq!(
-                    self.context.check_framebuffer_status(Context::FRAMEBUFFER),
-                    Context::FRAMEBUFFER_COMPLETE,
-                    "Framebuffer does not have status FRAMEBUFFER_COMPLETE."
-                );
+                // Check if we are ready to render. If we don't assert here we wil only get a warning
+                // that won't tell us where things went wrong.
+                {
+                    let framebuffer_status = context.check_framebuffer_status(Context::FRAMEBUFFER);
+                    debug_assert_eq!(
+                        framebuffer_status,
+                        Context::FRAMEBUFFER_COMPLETE,
+                        "Framebuffer does not have status FRAMEBUFFER_COMPLETE, but {}.",
+                        framebuffer_status
+                        )
+                }
 
                 self.stats.inc_draw_call_count();
                 if instance_count > 0 {

--- a/src/rust/ensogl/src/display/symbol/gpu.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu.rs
@@ -334,6 +334,7 @@ impl Symbol {
                 return;
             }
             self.with_program(|_|{
+
                 for binding in &self.bindings.borrow().uniforms {
                     binding.upload(&self.context);
                 }
@@ -353,6 +354,7 @@ impl Symbol {
                 let count          = self.surface.point_scope().size()    as i32;
                 let instance_count = self.surface.instance_scope().size() as i32;
 
+                // println!("{:?}", self.context.check_framebuffer_status(Context::FRAMEBUFFER));
                 self.stats.inc_draw_call_count();
                 if instance_count > 0 {
                     self.context.draw_arrays_instanced(mode,first,count,instance_count);

--- a/src/rust/ensogl/src/display/symbol/gpu.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu.rs
@@ -355,7 +355,7 @@ impl Symbol {
                     debug_assert_eq!(
                         framebuffer_status,
                         Context::FRAMEBUFFER_COMPLETE,
-                        "Framebuffer does not have status FRAMEBUFFER_COMPLETE, but {}.",
+                        "Framebuffer incomplete (status: {}).",
                         framebuffer_status
                         )
                 }

--- a/src/rust/ensogl/src/display/symbol/gpu.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu.rs
@@ -352,7 +352,8 @@ impl Symbol {
 
                 debug_assert_eq!(
                     self.context.check_framebuffer_status(Context::FRAMEBUFFER),
-                    Context::FRAMEBUFFER_COMPLETE
+                    Context::FRAMEBUFFER_COMPLETE,
+                    "Framebuffer does not have status FRAMEBUFFER_COMPLETE."
                 );
 
                 self.stats.inc_draw_call_count();

--- a/src/rust/ensogl/src/display/symbol/gpu.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu.rs
@@ -339,6 +339,11 @@ impl Symbol {
                 }
 
                 let context              = &self.context;
+
+                context
+                .get_extension("EXT_color_buffer_float")
+                .expect("Could not get WebGL extension EXT_color_buffer_float");
+
                 let textures             = &self.bindings.borrow().textures;
                 let bound_textures_iter  = textures.iter().map(|t| {t.bind_texture_unit(context)});
                 let _textures_keep_alive = bound_textures_iter.collect_vec();

--- a/src/rust/ensogl/src/display/symbol/gpu/geometry/compound/sprite.rs
+++ b/src/rust/ensogl/src/display/symbol/gpu/geometry/compound/sprite.rs
@@ -309,7 +309,7 @@ impl SpriteSystem {
         // FIXME outputs as the number of attachments to framebuffer. We should manage this more
         // FIXME intelligent. For example, we could allow defining output shader fragments,
         // FIXME which will be enabled only if pass of given attachment type was enabled.
-        material.add_output ("id", Vector4::<u32>::new(0,0,0,0));
+        material.add_output ("id", Vector4::<f32>::new(0.0,0.0,0.0,0.0));
         material.set_main("output_color = vec4(0.0,0.0,0.0,1.0); output_id=uvec4(0,0,0,0);");
         material
     }

--- a/src/rust/ensogl/src/display/world.rs
+++ b/src/rust/ensogl/src/display/world.rs
@@ -142,7 +142,7 @@ impl World {
 
     fn init_composer(&self) {
         let mouse_hover_ids     = self.scene.mouse.hover_ids.clone_ref();
-        let mut pixel_read_pass = PixelReadPass::<f32>::new(&self.scene.mouse.position);
+        let mut pixel_read_pass = PixelReadPass::<u8>::new(&self.scene.mouse.position);
         pixel_read_pass.set_callback(move |v| {
             mouse_hover_ids.set(Vector4::from_iterator(v.iter().map(|value| *value as u32)))
         });

--- a/src/rust/ensogl/src/display/world.rs
+++ b/src/rust/ensogl/src/display/world.rs
@@ -142,9 +142,9 @@ impl World {
 
     fn init_composer(&self) {
         let mouse_hover_ids     = self.scene.mouse.hover_ids.clone_ref();
-        let mut pixel_read_pass = PixelReadPass::<u32>::new(&self.scene.mouse.position);
+        let mut pixel_read_pass = PixelReadPass::<f32>::new(&self.scene.mouse.position);
         pixel_read_pass.set_callback(move |v| {
-            mouse_hover_ids.set(Vector4::from_iterator(v))
+            mouse_hover_ids.set(Vector4::from_iterator(v.iter().map(|value| *value as u32)))
         });
         // TODO: We may want to enable it on weak hardware.
         // pixel_read_pass.set_threshold(1);

--- a/src/rust/ensogl/src/system/gpu/data/texture/class.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/class.rs
@@ -58,7 +58,7 @@ impl Drop for TextureBindGuard {
 /// For more background see: https://developer.mozilla.org/en-US/docs/Web/API/WebGLRenderingContext/texParameter
 ///
 #[derive(Copy,Clone,Debug,Default)]
-pub struct Parameters{
+pub struct Parameters {
     /// Specifies the setting for the texture magnification filter (`Context::TEXTURE_MIN_FILTER`).
     pub min_filter : MinFilterValue,
     /// Specifies the setting for the texture minification filter (`Context::TEXTURE_MAG_FILTER`).
@@ -75,7 +75,7 @@ pub struct Parameters{
 
 impl Parameters {
     /// Sets the context parameters in the given context.
-    pub fn set_parameters(&self, context:&Context){
+    pub fn set_parameters(&self, context:&Context) {
         let target = Context::TEXTURE_2D;
         context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.min_filter.0 as i32);
         context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.mag_filter.0 as i32);
@@ -90,7 +90,7 @@ impl Parameters {
 /// Valid Parameters for the `gl.TEXTURE_MAG_FILTER` texture setting.
 /// Specifies how values are interpolated if the texture is rendered at a resolution that is
 /// lower than its native resolution.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy,Clone,Debug)]
 pub struct MagFilterValue(u32);
 
 #[allow(missing_docs)]
@@ -100,7 +100,7 @@ impl MagFilterValue {
 }
 
 // Note: The parameters implement our own default, not the WebGL one.
-impl Default for MagFilterValue{
+impl Default for MagFilterValue {
     fn default() -> Self {
         Self::LINEAR
     }
@@ -109,7 +109,7 @@ impl Default for MagFilterValue{
 /// Valid Parameters for the `gl.TEXTURE_MIN_FILTER` texture setting.
 /// Specifies how values are interpolated if the texture is rendered at a resolution that is
 /// lower than its native resolution.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy,Clone,Debug)]
 pub struct MinFilterValue(u32);
 
 #[allow(missing_docs)]
@@ -123,7 +123,7 @@ impl MinFilterValue {
 }
 
 // Note: The parameters implement our own default, not the WebGL one.
-impl Default for MinFilterValue{
+impl Default for MinFilterValue {
     fn default() -> Self {
         Self::LINEAR
     }
@@ -131,7 +131,7 @@ impl Default for MinFilterValue{
 
 /// Valid Parameters for the `gl.TEXTURE_WRAP_S` and `gl.TEXTURE_WRAP_T` texture setting.
 /// Specifies what happens if a texture is sampled out of bounds.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy,Clone,Debug)]
 pub struct WrapValue(u32);
 
 #[allow(missing_docs)]
@@ -142,7 +142,7 @@ impl WrapValue {
 }
 
 // Note: The parameters implement our own default, not the WebGL one.
-impl Default for WrapValue{
+impl Default for WrapValue {
     fn default() -> Self {
         Self::CLAMP_TO_EDGE
     }

--- a/src/rust/ensogl/src/system/gpu/data/texture/class.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/class.rs
@@ -60,25 +60,25 @@ impl Drop for TextureBindGuard {
 #[derive(Copy,Clone,Debug,Default)]
 pub struct Parameters {
     /// Specifies the setting for the texture magnification filter (`Context::TEXTURE_MIN_FILTER`).
-    pub min_filter : MinFilterValue,
+    pub min_filter : MinFilter,
     /// Specifies the setting for the texture minification filter (`Context::TEXTURE_MAG_FILTER`).
-    pub mag_filter : MagFilterValue,
+    pub mag_filter : MagFilter,
     /// Specifies the setting for the wrapping function for texture coordinate s
     /// (`Context::TEXTURE_WRAP_S`).
-    pub wrap_s     : WrapValue,
+    pub wrap_s     : Wrap,
     /// Specifies the setting for the wrapping function for texture coordinate t
     /// (`Context::TEXTURE_WRAP_T`).
-    pub wrap_t     : WrapValue,
+    pub wrap_t     : Wrap,
 }
 
 impl Parameters {
     /// Sets the context parameters in the given context.
     pub fn set_parameters(&self, context:&Context) {
         let target = Context::TEXTURE_2D;
-        context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.min_filter.0 as i32);
-        context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.mag_filter.0 as i32);
-        context.tex_parameteri(target,Context::TEXTURE_WRAP_S,self.wrap_s.0 as i32);
-        context.tex_parameteri(target,Context::TEXTURE_WRAP_T,self.wrap_t.0 as i32);
+        context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.min_filter.gl_value as i32);
+        context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.mag_filter.gl_value as i32);
+        context.tex_parameteri(target,Context::TEXTURE_WRAP_S,self.wrap_s.gl_value as i32);
+        context.tex_parameteri(target,Context::TEXTURE_WRAP_T,self.wrap_t.gl_value as i32);
     }
 }
 
@@ -86,61 +86,70 @@ impl Parameters {
 // === Parameter Types ===
 
 /// Valid Parameters for the `gl.TEXTURE_MAG_FILTER` texture setting.
+///
 /// Specifies how values are interpolated if the texture is rendered at a resolution that is
 /// lower than its native resolution.
 #[derive(Copy,Clone,Debug)]
-pub struct MagFilterValue(u32);
+pub struct MagFilter {
+    gl_value: u32
+}
 
 #[allow(missing_docs)]
-impl MagFilterValue {
-    pub const LINEAR  : MagFilterValue = Self(Context::LINEAR);
-    pub const NEAREST : MagFilterValue = Self(Context::NEAREST);
+impl MagFilter {
+    pub const LINEAR  : MagFilter = Self{gl_value:Context::LINEAR};
+    pub const NEAREST : MagFilter = Self{gl_value:Context::NEAREST};
 }
 
 // Note: The parameters implement our own default, not the WebGL one.
-impl Default for MagFilterValue {
+impl Default for MagFilter {
     fn default() -> Self {
         Self::LINEAR
     }
 }
 
 /// Valid Parameters for the `gl.TEXTURE_MIN_FILTER` texture setting.
+///
 /// Specifies how values are interpolated if the texture is rendered at a resolution that is
 /// lower than its native resolution.
 #[derive(Copy,Clone,Debug)]
-pub struct MinFilterValue(u32);
+pub struct MinFilter {
+    gl_value: u32
+}
 
 #[allow(missing_docs)]
-impl MinFilterValue {
-    pub const LINEAR                 : MinFilterValue = Self(Context::LINEAR);
-    pub const NEAREST                : MinFilterValue = Self(Context::NEAREST);
-    pub const NEAREST_MIPMAP_NEAREST : MinFilterValue = Self(Context::NEAREST_MIPMAP_NEAREST);
-    pub const LINEAR_MIPMAP_NEAREST  : MinFilterValue = Self(Context::LINEAR_MIPMAP_NEAREST);
-    pub const NEAREST_MIPMAP_LINEAR  : MinFilterValue = Self(Context::NEAREST_MIPMAP_LINEAR);
-    pub const LINEAR_MIPMAP_LINEAR   : MinFilterValue = Self(Context::LINEAR_MIPMAP_LINEAR);
+impl MinFilter {
+    pub const LINEAR                 : MinFilter = Self{gl_value:Context::LINEAR};
+    pub const NEAREST                : MinFilter = Self{gl_value:Context::NEAREST};
+    pub const NEAREST_MIPMAP_NEAREST : MinFilter = Self{gl_value:Context::NEAREST_MIPMAP_NEAREST};
+    pub const LINEAR_MIPMAP_NEAREST  : MinFilter = Self{gl_value:Context::LINEAR_MIPMAP_NEAREST};
+    pub const NEAREST_MIPMAP_LINEAR  : MinFilter = Self{gl_value:Context::NEAREST_MIPMAP_LINEAR};
+    pub const LINEAR_MIPMAP_LINEAR   : MinFilter = Self{gl_value:Context::LINEAR_MIPMAP_LINEAR};
 }
 
 // Note: The parameters implement our own default, not the WebGL one.
-impl Default for MinFilterValue {
+impl Default for MinFilter {
     fn default() -> Self {
         Self::LINEAR
     }
 }
 
 /// Valid Parameters for the `gl.TEXTURE_WRAP_S` and `gl.TEXTURE_WRAP_T` texture setting.
+///
 /// Specifies what happens if a texture is sampled out of bounds.
 #[derive(Copy,Clone,Debug)]
-pub struct WrapValue(u32);
+pub struct Wrap {
+    gl_value: u32
+}
 
 #[allow(missing_docs)]
-impl WrapValue {
-    pub const REPEAT          : WrapValue = Self(Context::REPEAT);
-    pub const CLAMP_TO_EDGE   : WrapValue = Self(Context::CLAMP_TO_EDGE);
-    pub const MIRRORED_REPEAT : WrapValue = Self(Context::MIRRORED_REPEAT);
+impl Wrap {
+    pub const REPEAT          : Wrap = Self{gl_value:Context::REPEAT};
+    pub const CLAMP_TO_EDGE   : Wrap = Self{gl_value:Context::CLAMP_TO_EDGE};
+    pub const MIRRORED_REPEAT : Wrap = Self{gl_value:Context::MIRRORED_REPEAT};
 }
 
 // Note: The parameters implement our own default, not the WebGL one.
-impl Default for WrapValue {
+impl Default for Wrap {
     fn default() -> Self {
         Self::CLAMP_TO_EDGE
     }
@@ -161,7 +170,6 @@ where Storage: StorageRelation<InternalFormat,ItemType> {
     storage    : StorageOf<Storage,InternalFormat,ItemType>,
     gl_texture : WebGlTexture,
     context    : Context,
-    /// Texture parameters that need to be set when binding the texture.
     parameters : Parameters
 }
 

--- a/src/rust/ensogl/src/system/gpu/data/texture/class.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/class.rs
@@ -53,22 +53,22 @@ impl Drop for TextureBindGuard {
 #[derive(Copy, Clone, Debug)]
 pub struct Parameters{
     /// Specifies the value for `Context::TEXTURE_MIN_FILTER`.
-    pub min_filter : i32,
+    pub min_filter : u32,
     /// Specifies the value for `Context::TEXTURE_MAG_FILTER`.
-    pub mag_filter : i32,
+    pub mag_filter : u32,
     /// Specifies the value for `Context::TEXTURE_WRAP_S`.
-    pub wrap_s     : i32,
+    pub wrap_s     : u32,
     /// Specifies the value for `Context::TEXTURE_WRAP_T`.
-    pub wrap_t     : i32,
+    pub wrap_t     : u32,
 }
 
 impl Default for Parameters{
     fn default() -> Self {
         Parameters{
-            min_filter : Context::LINEAR as i32,
-            mag_filter : Context::LINEAR as i32,
-            wrap_s     : Context::CLAMP_TO_EDGE as i32,
-            wrap_t     : Context::CLAMP_TO_EDGE as i32,
+            min_filter : Context::LINEAR,
+            mag_filter : Context::LINEAR,
+            wrap_s     : Context::CLAMP_TO_EDGE,
+            wrap_t     : Context::CLAMP_TO_EDGE,
         }
     }
 }
@@ -77,10 +77,10 @@ impl Parameters {
     /// Sets the context parameters in the given context.
     pub fn set_parameters(&self, context:&Context){
         let target = Context::TEXTURE_2D;
-        context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.min_filter);
-        context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.mag_filter);
-        context.tex_parameteri(target,Context::TEXTURE_WRAP_S,self.wrap_s);
-        context.tex_parameteri(target,Context::TEXTURE_WRAP_T,self.wrap_t);
+        context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.min_filter as i32);
+        context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.mag_filter as i32);
+        context.tex_parameteri(target,Context::TEXTURE_WRAP_S,self.wrap_s as i32);
+        context.tex_parameteri(target,Context::TEXTURE_WRAP_T,self.wrap_t as i32);
 
     }
 }

--- a/src/rust/ensogl/src/system/gpu/data/texture/class.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/class.rs
@@ -73,12 +73,6 @@ impl Default for Parameters{
     }
 }
 
-
-
-// ===============
-// === Texture ===
-// ===============
-
 impl Parameters {
     /// Sets the context parameters in the given context.
     pub fn set_parameters(&self, context:&Context){
@@ -92,15 +86,22 @@ impl Parameters {
 }
 
 
+
+// ===============
+// === Texture ===
+// ===============
+
+
+
 /// Texture bound to GL context.
 #[derive(Derivative)]
 #[derivative(Clone(bound="StorageOf<Storage,InternalFormat,ItemType>:Clone"))]
 #[derivative(Debug(bound="StorageOf<Storage,InternalFormat,ItemType>:Debug"))]
 pub struct Texture<Storage,InternalFormat,ItemType>
 where Storage: StorageRelation<InternalFormat,ItemType> {
-    storage        : StorageOf<Storage,InternalFormat,ItemType>,
-    gl_texture     : WebGlTexture,
-    context        : Context,
+        storage    : StorageOf<Storage,InternalFormat,ItemType>,
+        gl_texture : WebGlTexture,
+        context    : Context,
     /// Texture parameters that need to be set when binding the texture.
     pub parameters : Parameters
 }

--- a/src/rust/ensogl/src/system/gpu/data/texture/class.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/class.rs
@@ -118,11 +118,6 @@ pub enum MinFilter {
     LinearMipmapLinear   = Context::LINEAR_MIPMAP_LINEAR   as isize,
 }
 
-#[allow(missing_docs)]
-impl MinFilter {
-
-}
-
 // Note: The parameters implement our own default, not the WebGL one.
 impl Default for MinFilter {
     fn default() -> Self {

--- a/src/rust/ensogl/src/system/gpu/data/texture/class.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/class.rs
@@ -72,8 +72,8 @@ pub struct Parameters {
 }
 
 impl Parameters {
-    /// Sets the context parameters in the given context.
-    pub fn set_parameters(&self, context:&Context) {
+    /// Applies the context parameters in the given context.
+    pub fn apply_parameters(&self, context:&Context) {
         let target = Context::TEXTURE_2D;
         context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.min_filter.gl_value as i32);
         context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.mag_filter.gl_value as i32);
@@ -295,9 +295,9 @@ where S:StorageRelation<I,T> {
         Self {storage,gl_texture,context,parameters}
     }
 
-    /// Sets the texture wrapping parameters.
-    pub fn set_texture_parameters(&self, context:&Context) {
-        self.parameters.set_parameters(context);
+    /// Applies this textures' parameters in the given context.
+    pub fn apply_texture_parameters(&self, context:&Context) {
+        self.parameters.apply_parameters(context);
     }
 }
 
@@ -326,7 +326,7 @@ where S : StorageRelation<I,T>,
             result.unwrap();
         }
 
-        self.set_texture_parameters(&self.context);
+        self.apply_texture_parameters(&self.context);
     }
 }
 

--- a/src/rust/ensogl/src/system/gpu/data/texture/class.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/class.rs
@@ -45,9 +45,9 @@ impl Drop for TextureBindGuard {
 
 
 
-// ===============
-// === Texture ===
-// ===============
+// ==================
+// === Parameters ===
+// ==================
 
 /// Parameters that need to be set when binding a texture.
 #[derive(Copy, Clone, Debug)]
@@ -73,6 +73,12 @@ impl Default for Parameters{
     }
 }
 
+
+
+// ===============
+// === Texture ===
+// ===============
+
 impl Parameters {
     /// Sets the context parameters in the given context.
     pub fn set_parameters(&self, context:&Context){
@@ -92,10 +98,9 @@ impl Parameters {
 #[derivative(Debug(bound="StorageOf<Storage,InternalFormat,ItemType>:Debug"))]
 pub struct Texture<Storage,InternalFormat,ItemType>
 where Storage: StorageRelation<InternalFormat,ItemType> {
-    storage    : StorageOf<Storage,InternalFormat,ItemType>,
-    gl_texture : WebGlTexture,
-    context    : Context,
-
+    storage        : StorageOf<Storage,InternalFormat,ItemType>,
+    gl_texture     : WebGlTexture,
+    context        : Context,
     /// Texture parameters that need to be set when binding the texture.
     pub parameters : Parameters
 }

--- a/src/rust/ensogl/src/system/gpu/data/texture/class.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/class.rs
@@ -73,12 +73,12 @@ pub struct Parameters {
 
 impl Parameters {
     /// Applies the context parameters in the given context.
-    pub fn apply_parameters(&self, context:&Context) {
+    pub fn apply_parameters(self, context:&Context) {
         let target = Context::TEXTURE_2D;
-        context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.min_filter.gl_value as i32);
-        context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.mag_filter.gl_value as i32);
-        context.tex_parameteri(target,Context::TEXTURE_WRAP_S,self.wrap_s.gl_value as i32);
-        context.tex_parameteri(target,Context::TEXTURE_WRAP_T,self.wrap_t.gl_value as i32);
+        context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.min_filter as i32);
+        context.tex_parameteri(target,Context::TEXTURE_MIN_FILTER,self.mag_filter as i32);
+        context.tex_parameteri(target,Context::TEXTURE_WRAP_S,self.wrap_s as i32);
+        context.tex_parameteri(target,Context::TEXTURE_WRAP_T,self.wrap_t as i32);
     }
 }
 
@@ -90,20 +90,16 @@ impl Parameters {
 /// Specifies how values are interpolated if the texture is rendered at a resolution that is
 /// lower than its native resolution.
 #[derive(Copy,Clone,Debug)]
-pub struct MagFilter {
-    gl_value: u32
-}
-
 #[allow(missing_docs)]
-impl MagFilter {
-    pub const LINEAR  : MagFilter = Self{gl_value:Context::LINEAR};
-    pub const NEAREST : MagFilter = Self{gl_value:Context::NEAREST};
+pub enum MagFilter {
+    Linear  = Context::LINEAR  as isize,
+    Nearest = Context::NEAREST as isize,
 }
 
 // Note: The parameters implement our own default, not the WebGL one.
 impl Default for MagFilter {
     fn default() -> Self {
-        Self::LINEAR
+        Self::Linear
     }
 }
 
@@ -112,24 +108,25 @@ impl Default for MagFilter {
 /// Specifies how values are interpolated if the texture is rendered at a resolution that is
 /// lower than its native resolution.
 #[derive(Copy,Clone,Debug)]
-pub struct MinFilter {
-    gl_value: u32
+#[allow(missing_docs)]
+pub enum MinFilter {
+    Linear               = Context::LINEAR                 as isize,
+    Nearest              = Context::NEAREST                as isize,
+    NearestMipmapNearest = Context::NEAREST_MIPMAP_NEAREST as isize,
+    LinearMipmapNearest  = Context::LINEAR_MIPMAP_NEAREST  as isize,
+    NearestMipmapLinear  = Context::NEAREST_MIPMAP_LINEAR  as isize,
+    LinearMipmapLinear   = Context::LINEAR_MIPMAP_LINEAR   as isize,
 }
 
 #[allow(missing_docs)]
 impl MinFilter {
-    pub const LINEAR                 : MinFilter = Self{gl_value:Context::LINEAR};
-    pub const NEAREST                : MinFilter = Self{gl_value:Context::NEAREST};
-    pub const NEAREST_MIPMAP_NEAREST : MinFilter = Self{gl_value:Context::NEAREST_MIPMAP_NEAREST};
-    pub const LINEAR_MIPMAP_NEAREST  : MinFilter = Self{gl_value:Context::LINEAR_MIPMAP_NEAREST};
-    pub const NEAREST_MIPMAP_LINEAR  : MinFilter = Self{gl_value:Context::NEAREST_MIPMAP_LINEAR};
-    pub const LINEAR_MIPMAP_LINEAR   : MinFilter = Self{gl_value:Context::LINEAR_MIPMAP_LINEAR};
+
 }
 
 // Note: The parameters implement our own default, not the WebGL one.
 impl Default for MinFilter {
     fn default() -> Self {
-        Self::LINEAR
+        Self::Linear
     }
 }
 
@@ -137,21 +134,17 @@ impl Default for MinFilter {
 ///
 /// Specifies what happens if a texture is sampled out of bounds.
 #[derive(Copy,Clone,Debug)]
-pub struct Wrap {
-    gl_value: u32
-}
-
 #[allow(missing_docs)]
-impl Wrap {
-    pub const REPEAT          : Wrap = Self{gl_value:Context::REPEAT};
-    pub const CLAMP_TO_EDGE   : Wrap = Self{gl_value:Context::CLAMP_TO_EDGE};
-    pub const MIRRORED_REPEAT : Wrap = Self{gl_value:Context::MIRRORED_REPEAT};
+pub enum Wrap {
+    Repeat         = Context::REPEAT          as isize,
+    ClampToEdge    = Context::CLAMP_TO_EDGE   as isize,
+    MirroredRepeat = Context::MIRRORED_REPEAT as isize,
 }
 
 // Note: The parameters implement our own default, not the WebGL one.
 impl Default for Wrap {
     fn default() -> Self {
-        Self::CLAMP_TO_EDGE
+        Self::ClampToEdge
     }
 }
 

--- a/src/rust/ensogl/src/system/gpu/data/texture/class.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/class.rs
@@ -71,8 +71,6 @@ pub struct Parameters {
     pub wrap_t     : WrapValue,
 }
 
-
-
 impl Parameters {
     /// Sets the context parameters in the given context.
     pub fn set_parameters(&self, context:&Context) {

--- a/src/rust/ensogl/src/system/gpu/data/texture/storage/gpu_only.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/storage/gpu_only.rs
@@ -62,7 +62,7 @@ TextureReload for Texture<GpuOnly,I,T> {
         self.context().tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array
         (target,level,internal_format,width,height,border,format,elem_type,None).unwrap();
 
-        Self::set_texture_parameters(self.context());
+        self.set_texture_parameters(self.context());
     }
 }
 

--- a/src/rust/ensogl/src/system/gpu/data/texture/storage/gpu_only.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/storage/gpu_only.rs
@@ -62,7 +62,7 @@ TextureReload for Texture<GpuOnly,I,T> {
         self.context().tex_image_2d_with_i32_and_i32_and_i32_and_format_and_type_and_opt_u8_array
         (target,level,internal_format,width,height,border,format,elem_type,None).unwrap();
 
-        self.set_texture_parameters(self.context());
+        self.apply_texture_parameters(self.context());
     }
 }
 

--- a/src/rust/ensogl/src/system/gpu/data/texture/storage/remote_image.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/storage/remote_image.rs
@@ -82,6 +82,7 @@ TextureReload for Texture<RemoteImage,I,T> {
         let image_ref_opt = image_ref.clone();
         let context       = self.context().clone();
         let gl_texture    = self.gl_texture().clone();
+        let parameters    = self.parameters;
         let callback: Closure<dyn FnMut()> = Closure::once(move || {
             let _keep_alive     = callback_ref2;
             let image           = image_ref_opt.borrow();
@@ -94,7 +95,7 @@ TextureReload for Texture<RemoteImage,I,T> {
             context.tex_image_2d_with_u32_and_u32_and_html_image_element
             (target,level,internal_format,format,elem_type,&image).unwrap();
 
-            Self::set_texture_parameters(&context);
+            parameters.set_parameters(&context);
         });
         let js_callback = callback.as_ref().unchecked_ref();
         let image       = image_ref.borrow();

--- a/src/rust/ensogl/src/system/gpu/data/texture/storage/remote_image.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/storage/remote_image.rs
@@ -82,7 +82,7 @@ TextureReload for Texture<RemoteImage,I,T> {
         let image_ref_opt = image_ref.clone();
         let context       = self.context().clone();
         let gl_texture    = self.gl_texture().clone();
-        let parameters    = self.parameters;
+        let parameters    = *self.parameters();
         let callback: Closure<dyn FnMut()> = Closure::once(move || {
             let _keep_alive     = callback_ref2;
             let image           = image_ref_opt.borrow();

--- a/src/rust/ensogl/src/system/gpu/data/texture/storage/remote_image.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/storage/remote_image.rs
@@ -95,7 +95,7 @@ TextureReload for Texture<RemoteImage,I,T> {
             context.tex_image_2d_with_u32_and_u32_and_html_image_element
             (target,level,internal_format,format,elem_type,&image).unwrap();
 
-            parameters.set_parameters(&context);
+            parameters.apply_parameters(&context);
         });
         let js_callback = callback.as_ref().unchecked_ref();
         let image       = image_ref.borrow();

--- a/src/rust/ensogl/src/system/gpu/data/texture/types/relations.rs
+++ b/src/rust/ensogl/src/system/gpu/data/texture/types/relations.rs
@@ -25,6 +25,11 @@
 ///   currently stored pixel. Blending applies only in RGBA mode and only if the color buffer has a
 ///   fixed-point or floating-point format; in color index mode or if the color buffer has an
 ///   integer format, it is bypassed.
+///
+/// The features of some texture formats can be modified through extensions. For example, the
+/// the extension `EXT_color_buffer_float` can make the group of float texture (e.g., `Rgba32f`)
+/// color renderable.
+///
 #[macro_export]
 macro_rules! with_texture_format_relations { ($f:ident $args:tt) => { $crate::$f! { $args
 //  INTERNAL_FORMAT   FORMAT         SAMPLER      COL   FILT  BLEND [POSSIBLE_TYPE:BYTES_PER_TEXTURE_ELEM]

--- a/src/rust/ensogl/src/system/gpu/data/uniform.rs
+++ b/src/rust/ensogl/src/system/gpu/data/uniform.rs
@@ -342,7 +342,7 @@ macro_rules! define_get_or_add_gpu_texture_dyn {
                     let mut texture = Texture::<GpuOnly,$internal_format,$item_type>
                                 ::new(&context,provider);
                     if let Some(parameters) = parameters {
-                        texture.parameters = parameters;
+                        texture.set_parameters(parameters);
                     }
                     let uniform = scope.get_or_add(name,texture).unwrap();
                     uniform.into()

--- a/src/rust/ensogl/src/system/gpu/data/uniform.rs
+++ b/src/rust/ensogl/src/system/gpu/data/uniform.rs
@@ -334,13 +334,18 @@ macro_rules! define_get_or_add_gpu_texture_dyn {
         , internal_format : AnyInternalFormat
         , item_type       : AnyItemType
         , provider        : P
+        , parameters      : Option<Parameters>
         ) -> AnyTextureUniform {
             let provider = provider.into();
             match (internal_format,item_type) {
                 $((AnyInternalFormat::$internal_format, AnyItemType::$item_type) => {
-                    let texture = Texture::<GpuOnly,$internal_format,$item_type>
+                    let mut texture = Texture::<GpuOnly,$internal_format,$item_type>
                                 ::new(&context,provider);
+                    if let Some(parameters) = parameters{
+                        texture.parameters = parameters;
+                    }
                     let uniform = scope.get_or_add(name,texture).unwrap();
+
                     uniform.into()
                 })*
                 _ => panic!("Invalid (internal format, item type) combination.")

--- a/src/rust/ensogl/src/system/gpu/data/uniform.rs
+++ b/src/rust/ensogl/src/system/gpu/data/uniform.rs
@@ -341,11 +341,10 @@ macro_rules! define_get_or_add_gpu_texture_dyn {
                 $((AnyInternalFormat::$internal_format, AnyItemType::$item_type) => {
                     let mut texture = Texture::<GpuOnly,$internal_format,$item_type>
                                 ::new(&context,provider);
-                    if let Some(parameters) = parameters{
+                    if let Some(parameters) = parameters {
                         texture.parameters = parameters;
                     }
                     let uniform = scope.get_or_add(name,texture).unwrap();
-
                     uniform.into()
                 })*
                 _ => panic!("Invalid (internal format, item type) combination.")

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -255,10 +255,10 @@ impl Node {
         }
 
         // TODO this is sample functionality. Needs to be replaced with logic creating ports.
-        // let input_port = self.data.ports.input.create(&self);
-        // input_port.set_position(90.0_f32.degrees());
-        // let output_port = self.data.ports.output.create(&self);
-        // output_port.set_position(270.0_f32.degrees());
+        let input_port = self.data.ports.input.create(&self);
+        input_port.set_position(90.0_f32.degrees());
+        let output_port = self.data.ports.output.create(&self);
+        output_port.set_position(270.0_f32.degrees());
 
         self
     }

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -255,10 +255,10 @@ impl Node {
         }
 
         // TODO this is sample functionality. Needs to be replaced with logic creating ports.
-        let input_port = self.data.ports.input.create(&self);
-        input_port.set_position(90.0_f32.degrees());
-        let output_port = self.data.ports.output.create(&self);
-        output_port.set_position(270.0_f32.degrees());
+        // let input_port = self.data.ports.input.create(&self);
+        // input_port.set_position(90.0_f32.degrees());
+        // let output_port = self.data.ports.output.create(&self);
+        // output_port.set_position(270.0_f32.degrees());
 
         self
     }

--- a/src/rust/lib/system/web/src/lib.rs
+++ b/src/rust/lib/system/web/src/lib.rs
@@ -204,11 +204,6 @@ pub fn get_webgl2_context(canvas:&HtmlCanvasElement) -> WebGl2RenderingContext {
     js_sys::Reflect::set(&options, &"antialias".into(), &false.into()).unwrap();
     let context = canvas.get_context_with_context_options("webgl2",&options).unwrap().unwrap();
     let context : WebGl2RenderingContext =  context.dyn_into().unwrap();
-    // Add this extension so we can use RGB32f textures for rendering object ids in our picking
-    // pipeline.
-    context
-        .get_extension("EXT_color_buffer_float")
-        .expect("Could not get WebGL extension EXT_color_buffer_float");
     context
 }
 

--- a/src/rust/lib/system/web/src/lib.rs
+++ b/src/rust/lib/system/web/src/lib.rs
@@ -204,6 +204,8 @@ pub fn get_webgl2_context(canvas:&HtmlCanvasElement) -> WebGl2RenderingContext {
     js_sys::Reflect::set(&options, &"antialias".into(), &false.into()).unwrap();
     let context = canvas.get_context_with_context_options("webgl2",&options).unwrap().unwrap();
     let context : WebGl2RenderingContext =  context.dyn_into().unwrap();
+    // Add this extension so we can use RGB32f textures for rendering object ids in our picking
+    // pipeline.
     context
         .get_extension("EXT_color_buffer_float")
         .expect("Could not get WebGL extension EXT_color_buffer_float");

--- a/src/rust/lib/system/web/src/lib.rs
+++ b/src/rust/lib/system/web/src/lib.rs
@@ -203,7 +203,11 @@ pub fn get_webgl2_context(canvas:&HtmlCanvasElement) -> WebGl2RenderingContext {
     let options = js_sys::Object::new();
     js_sys::Reflect::set(&options, &"antialias".into(), &false.into()).unwrap();
     let context = canvas.get_context_with_context_options("webgl2",&options).unwrap().unwrap();
-    context.dyn_into().unwrap()
+    let context : WebGl2RenderingContext =  context.dyn_into().unwrap();
+    context
+        .get_extension("EXT_color_buffer_float")
+        .expect("Could not get WebGL extension EXT_color_buffer_float");
+    context
 }
 
 pub fn try_request_animation_frame(f:&Closure<dyn FnMut(f64)>) -> Result<i32> {


### PR DESCRIPTION
### Pull Request Description
This PR addresses issue #317 by changing the texture format of symbol IDs to `Rgba32f`. This enables correct selections of nodes close to each other.

This also seems to resolve #331 .

### Important Notes
This PR adds a requirement for the WebGL extension `EXT_color_buffer_float` to allow us the use of a float buffer.

This PR adds a new API to specify parameters for textures, which is required to set non-default parameters for the float texture.

As opposed to the requirements in isssue #317 this PR does not implement bit-reinterpretation between floats and integers, as these can lead to[ unexpected issues with `NaN`s](https://doc.rust-lang.org/1.19.0/std/primitive.f64.html#method.from_bits), which might lead to unexpected issues down the line. Instead, the numbers are cast between the datatypes.


### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

