### PR TITLE
Double Representation Connection operations

### DIFF
--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -1189,6 +1189,7 @@ dependencies = [
  "serde 1.0.106 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.51 (registry+https://github.com/rust-lang/crates.io-index)",
  "shapely 0.1.0",
+ "span-tree 0.1.0",
  "utils 0.1.0",
  "uuid 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasm-bindgen 0.2.58 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/rust/ide/Cargo.toml
+++ b/src/rust/ide/Cargo.toml
@@ -22,6 +22,7 @@ file-manager-client      = { version = "0.1.0"  , path = "file-manager"         
 json-rpc                 = { version = "0.1.0"  , path = "json-rpc"             }
 parser                   = { version = "0.1.0"  , path = "parser"               }
 utils                    = { version = "0.1.0"  , path = "utils"                }
+span-tree                = { version = "0.1.0"  , path = "span-tree"            }
 
 console_error_panic_hook = { version = "0.1.6"                                   }
 failure                  = { version = "0.1.6"                                   }

--- a/src/rust/ide/ast/impl/src/crumbs.rs
+++ b/src/rust/ide/ast/impl/src/crumbs.rs
@@ -104,11 +104,16 @@ struct MismatchedCrumbType;
 pub trait IntoCrumbs : IntoIterator<Item:Into<Crumb>> + Sized {
     /// Convert to the actual Crumbs structure.
     fn into_crumbs(self) -> Crumbs {
-        self.into_iter().map(|cb| cb.into()).collect()
+        iter_crumbs(self).collect()
     }
 }
 
 impl<T:IntoIterator<Item:Into<Crumb>> + Sized> IntoCrumbs for T {}
+
+/// Converts `IntoCrumbs` value into a `Crumb`-yielding iterator.
+pub fn iter_crumbs(crumbs:impl IntoCrumbs) -> impl Iterator<Item=Crumb> {
+    crumbs.into_iter().map(|crumb| crumb.into())
+}
 
 /// Sequence of `Crumb`s describing traversal path through AST.
 pub type Crumbs = Vec<Crumb>;
@@ -116,8 +121,11 @@ pub type Crumbs = Vec<Crumb>;
 /// Helper macro. Behaves like `vec!` but converts each element into `Crumb`.
 #[macro_export]
 macro_rules! crumbs {
+    ( ) => {
+        Vec::<$crate::crumbs::Crumb>::new()
+    };
     ( $( $x:expr ),* ) => {
-        vec![$(Crumb::from($x)),*]
+        vec![$($crate::crumbs::Crumb::from($x)),*]
     };
 }
 

--- a/src/rust/ide/ast/impl/src/lib.rs
+++ b/src/rust/ide/ast/impl/src/lib.rs
@@ -37,6 +37,7 @@ pub mod prelude {
 
 use crate::prelude::*;
 
+pub use crumbs::Crumb;
 pub use crumbs::Crumbs;
 
 use ast_macros::*;

--- a/src/rust/ide/ast/impl/src/lib.rs
+++ b/src/rust/ide/ast/impl/src/lib.rs
@@ -1115,6 +1115,11 @@ impl Ast {
     // TODO smart constructors for other cases
     //  as part of https://github.com/luna/enso/issues/338
 
+    /// Creates Blank ast node (underscore).
+    pub fn blank() -> Ast {
+        Ast::from(Blank{})
+    }
+
     /// Creates an Ast node with Number inside.
     pub fn number(number:i64) -> Ast {
         let number = Number {base:None,int:number.to_string()};

--- a/src/rust/ide/ast/impl/src/opr.rs
+++ b/src/rust/ide/ast/impl/src/opr.rs
@@ -7,6 +7,8 @@ use crate::SectionLeft;
 use crate::SectionRight;
 use crate::SectionSides;
 use crate::Ast;
+use crate::Shifted;
+use crate::Opr;
 use crate::Shape;
 use crate::assoc::Assoc;
 use crate::crumbs::Crumb;
@@ -65,6 +67,14 @@ pub fn to_arrow(ast:&Ast) -> Option<known::Infix> {
 pub fn is_assignment(ast:&Ast) -> bool {
     let infix = known::Infix::try_from(ast);
     infix.map(|infix| is_assignment_opr(&infix.opr)).unwrap_or(false)
+}
+
+/// Obtains a new `Opr` with an assignment.
+pub fn assignment() -> known::Opr {
+    // TODO? We could cache and reuse, if we care.
+    let name = predefined::ASSIGNMENT.into();
+    let opr = Opr {name};
+    known::Opr::new(opr,None)
 }
 
 
@@ -497,6 +507,13 @@ mod tests {
         expect_at(&chain.target,&c);
         expect_at(&chain.args[0].operand,&b);
         expect_at(&chain.args[1].operand,&a);
+    }
+
+    #[test]
+    fn assignment_opr_test() {
+        let opr = assignment();
+        assert_eq!(opr.name, "=");
+        assert_eq!(opr.repr(), "=");
     }
 
     // TODO[ao] add tests for modifying chain.

--- a/src/rust/ide/ast/impl/src/opr.rs
+++ b/src/rust/ide/ast/impl/src/opr.rs
@@ -7,7 +7,6 @@ use crate::SectionLeft;
 use crate::SectionRight;
 use crate::SectionSides;
 use crate::Ast;
-use crate::Shifted;
 use crate::Opr;
 use crate::Shape;
 use crate::assoc::Assoc;
@@ -18,6 +17,7 @@ use crate::crumbs::SectionRightCrumb;
 use crate::crumbs::SectionSidesCrumb;
 use crate::crumbs::Located;
 use crate::known;
+
 use utils::vec::VecExt;
 
 

--- a/src/rust/ide/span-tree/src/action.rs
+++ b/src/rust/ide/span-tree/src/action.rs
@@ -159,8 +159,8 @@ impl<'a> Implementation for node::Ref<'a> {
     fn erase_impl(&self) -> Option<EraseOperation> {
 
         match self.node.kind {
-            node::Kind::Argument{removable:true} |
-            node::Kind::Target  {removable:true} => Some(Box::new(move |root| {
+            node::Kind::Argument{removable:true,..} |
+            node::Kind::Target  {removable:true}    => Some(Box::new(move |root| {
                 let parent_crumb = &self.ast_crumbs[..self.ast_crumbs.len()-1];
                 let ast          = root.get_traversing(parent_crumb)?;
                 let new_ast = if let Some(mut infix) = ast::opr::Chain::try_new(ast) {

--- a/src/rust/ide/span-tree/src/iter.rs
+++ b/src/rust/ide/span-tree/src/iter.rs
@@ -42,7 +42,7 @@ impl<'a> Iterator for LeafIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.next_node.is_some() {
             let crumbs       = self.stack.iter().map(|sf| sf.child_being_visited);
-            let return_value = self.base_node.clone().traverse_subnode(crumbs);
+            let return_value = self.base_node.clone().get_subnode(crumbs);
             self.make_dfs_step();
             self.descend_to_leaf();
             return_value

--- a/src/rust/ide/span-tree/src/iter.rs
+++ b/src/rust/ide/span-tree/src/iter.rs
@@ -42,7 +42,7 @@ impl<'a> Iterator for LeafIterator<'a> {
     fn next(&mut self) -> Option<Self::Item> {
         if self.next_node.is_some() {
             let crumbs       = self.stack.iter().map(|sf| sf.child_being_visited);
-            let return_value = self.base_node.clone().get_subnode(crumbs);
+            let return_value = self.base_node.clone().get_descendant(crumbs);
             self.make_dfs_step();
             self.descend_to_leaf();
             return_value

--- a/src/rust/ide/span-tree/src/lib.rs
+++ b/src/rust/ide/span-tree/src/lib.rs
@@ -127,11 +127,11 @@ impl SpanTree {
     }
 
     /// Converts `SpanTree` crumbs to `Ast` crumbs.
-    pub fn convert_to_ast_crumbs(&self, crumbs:&SplitCrumbs) -> Option<ast::Crumbs> {
+    pub fn convert_to_ast_crumbs(&self, crumbs:SplitCrumbs) -> Option<ast::Crumbs> {
         let root = self.root_ref();
         let node_ref = root.traverse_subnode(crumbs.head.iter().copied())?;
         let mut ret = node_ref.ast_crumbs;
-        ret.extend(&crumbs.tail);
+        ret.extend(crumbs.tail);
         Some(ret)
     }
 }
@@ -152,7 +152,7 @@ mod test {
 
         let test_conversions0 = |ast_crumbs:ast::Crumbs, crumbs:SplitCrumbs| {
             assert_eq!(tree.convert_from_ast_crumbs(&ast_crumbs), crumbs);
-            assert_eq!(tree.convert_to_ast_crumbs(&crumbs).as_ref(), Some(&ast_crumbs));
+            assert_eq!(tree.convert_to_ast_crumbs(crumbs).as_ref(), Some(&ast_crumbs));
         };
 
         // Tester to be used when the crumb refers to span tree node.

--- a/src/rust/ide/span-tree/src/lib.rs
+++ b/src/rust/ide/span-tree/src/lib.rs
@@ -50,12 +50,6 @@ use prelude::*;
 // === Crumbs ===
 // ==============
 
-/// Crumb identifies subtree within a node. It is the index of the child node.
-pub type Crumb = usize;
-
-/// Crumbs identifying node's location in the span tree.
-pub type Crumbs = Vec<Crumb>;
-
 /// A possible connection endpoint described by span tree crumbs and ast crumbs.
 ///
 /// In case that endpoint is the span tree node, ast crumbs are empty. Otherwise, they are relative
@@ -63,7 +57,7 @@ pub type Crumbs = Vec<Crumb>;
 #[derive(Clone,Debug,Default,PartialEq,PartialOrd)]
 pub struct SplitCrumbs {
     /// Crumbs to a Span Tree leaf.
-    pub head : Crumbs,
+    pub head : Vec<usize>,
     /// Crumbs for traversing AST corresponding to the span tree leaf.
     /// Might be empty, if the span tree node corresponds to the desired AST node.
     pub tail : ast::Crumbs,
@@ -74,18 +68,19 @@ impl SplitCrumbs {
     (span_crumbs:impl IntoIterator<Item=usize>, ast_crumbs:impl ast::crumbs::IntoCrumbs)
      -> SplitCrumbs {
         SplitCrumbs {
-            head : Crumbs::from_iter(span_crumbs.into_iter()),
+            head : span_crumbs.into_iter().collect(),
             tail : ast_crumbs.into_crumbs(),
         }
     }
 
     pub fn new_span(span_crumbs:impl IntoIterator<Item=usize>) -> SplitCrumbs {
         SplitCrumbs {
-            head : Crumbs::from_iter(span_crumbs.into_iter()),
+            head : span_crumbs.into_iter().collect(),
             tail : default(),
         }
     }
 }
+
 
 
 // ================
@@ -167,7 +162,7 @@ mod test {
         };
 
         let expect_node_mismatch = |ast_crumbs:ast::Crumbs| {
-            let split_crumbs = SplitCrumbs::new(vec![],&ast_crumbs);
+            let split_crumbs = SplitCrumbs::new(vec![],ast_crumbs.iter().cloned());
             test_conversions0(ast_crumbs,split_crumbs)
         };
 

--- a/src/rust/ide/span-tree/src/lib.rs
+++ b/src/rust/ide/span-tree/src/lib.rs
@@ -38,12 +38,12 @@ pub mod traits {
 /// Common types that should be visible across the whole crate.
 pub mod prelude {
     pub use crate::traits::*;
+    pub use ast::traits::*;
     pub use enso_prelude::*;
     pub use utils::fail::FallibleResult;
 }
 
 use prelude::*;
-
 
 
 // ==============
@@ -56,6 +56,36 @@ pub type Crumb = usize;
 /// Crumbs identifying node's location in the span tree.
 pub type Crumbs = Vec<Crumb>;
 
+/// A possible connection endpoint described by span tree crumbs and ast crumbs.
+///
+/// In case that endpoint is the span tree node, ast crumbs are empty. Otherwise, they are relative
+/// to the AST corresponding to the span tree node.
+#[derive(Clone,Debug,Default,PartialEq,PartialOrd)]
+pub struct SplitCrumbs {
+    /// Crumbs to a Span Tree leaf.
+    pub head : Crumbs,
+    /// Crumbs for traversing AST corresponding to the span tree leaf.
+    /// Might be empty, if the span tree node corresponds to the desired AST node.
+    pub tail : ast::Crumbs,
+}
+
+impl SplitCrumbs {
+    pub fn new
+    (span_crumbs:impl IntoIterator<Item=usize>, ast_crumbs:impl ast::crumbs::IntoCrumbs)
+     -> SplitCrumbs {
+        SplitCrumbs {
+            head : Crumbs::from_iter(span_crumbs.into_iter()),
+            tail : ast_crumbs.into_crumbs(),
+        }
+    }
+
+    pub fn new_span(span_crumbs:impl IntoIterator<Item=usize>) -> SplitCrumbs {
+        SplitCrumbs {
+            head : Crumbs::from_iter(span_crumbs.into_iter()),
+            tail : default(),
+        }
+    }
+}
 
 
 // ================
@@ -89,12 +119,20 @@ impl SpanTree {
     }
 
     /// Converts `Ast` crumbs to `SpanTree` crumbs.
-    pub fn convert_from_ast_crumbs(&self, ast_crumbs:&[ast::Crumb]) -> Option<Vec<usize>> {
+    ///
+    /// Interestingly, this never fails. At worst none of the Ast crumbs will be matched and all
+    /// will be placed in the `tail` part of or the `SplitCrumbs`.
+    pub fn convert_from_ast_crumbs(&self, ast_crumbs:&[ast::Crumb]) -> SplitCrumbs {
         self.root.convert_from_ast_crumbs(ast_crumbs)
     }
 
-    pub fn convert_to_ast_crumbs(&self, crumbs:&[Crumb]) -> Option<ast::Crumbs> {
-        self.root.convert_to_ast_crumbs(crumbs)
+    /// Converts `SpanTree` crumbs to `Ast` crumbs.
+    pub fn convert_to_ast_crumbs(&self, crumbs:&SplitCrumbs) -> Option<ast::Crumbs> {
+        let root = self.root_ref();
+        let node_ref = root.traverse_subnode(crumbs.head.iter().copied())?;
+        let mut ret = node_ref.ast_crumbs;
+        ret.extend(&crumbs.tail);
+        Some(ret)
     }
 }
 
@@ -104,7 +142,7 @@ mod test {
     use ast::crumbs;
 
     #[test]
-    fn ast_crumbs_to_span_tree_crumbs() {
+    fn crumb_conversion_test() {
         let code = "1 + 2 + 3";
         let ast  = parser::Parser::new_or_panic().parse_line(code).unwrap();
         let tree = SpanTree::new(&ast).unwrap();
@@ -112,25 +150,44 @@ mod test {
         use ast::crumbs::InfixCrumb::*;
         use ast::crumbs::PrefixCrumb::*;
 
-        let test_conversions = |ast_crumbs:ast::Crumbs, crumbs:Crumbs| {
-            assert_eq!(tree.convert_from_ast_crumbs(&ast_crumbs).as_ref(), Some(&crumbs));
-            assert_eq!(tree.convert_to_ast_crumbs(&crumbs).as_ref(),       Some(&ast_crumbs));
+        let test_conversions0 = |ast_crumbs:ast::Crumbs, crumbs:SplitCrumbs| {
+            assert_eq!(tree.convert_from_ast_crumbs(&ast_crumbs), crumbs);
+            assert_eq!(tree.convert_to_ast_crumbs(&crumbs).as_ref(), Some(&ast_crumbs));
         };
 
-        test_conversions(crumbs![],                         vec![]   );
-        test_conversions(crumbs![LeftOperand],              vec![0]  );
-        test_conversions(crumbs![Operator],                 vec![1]  );
-        test_conversions(crumbs![RightOperand],             vec![2]  );
-        test_conversions(crumbs![LeftOperand,LeftOperand],  vec![0,0]);
-        test_conversions(crumbs![LeftOperand,Operator],     vec![0,1]);
-        test_conversions(crumbs![LeftOperand,RightOperand], vec![0,2]);
+        // Tester to be used when the crumb refers to span tree node.
+        let expect_node_match = |ast_crumbs:ast::Crumbs, crumbs:&[usize]| {
+            let split_crumbs = SplitCrumbs::new_span(crumbs.iter().copied());
+            test_conversions0(ast_crumbs,split_crumbs)
+        };
 
-        assert!(tree.convert_from_ast_crumbs(&crumbs![Arg]).is_none());
-        assert!(tree.convert_from_ast_crumbs(&crumbs![LeftOperand,Arg]).is_none());
-        assert!(tree.convert_from_ast_crumbs(&crumbs![RightOperand,LeftOperand]).is_none());
+        let sub_node_match = |ast_crumbs:ast::Crumbs, head:&[usize], tail:ast::Crumbs| {
+            let split_crumbs = SplitCrumbs::new(head.iter().copied(),tail);
+            test_conversions0(ast_crumbs,split_crumbs)
+        };
 
-        assert!(tree.convert_to_ast_crumbs(&vec![4]).is_none());
-        assert!(tree.convert_to_ast_crumbs(&vec![1,5]).is_none());
-        assert!(tree.convert_to_ast_crumbs(&vec![0,0,0]).is_none());
+        let expect_node_mismatch = |ast_crumbs:ast::Crumbs| {
+            let split_crumbs = SplitCrumbs::new(vec![],&ast_crumbs);
+            test_conversions0(ast_crumbs,split_crumbs)
+        };
+
+        expect_node_match(crumbs![],                         &[]   );
+        expect_node_match(crumbs![LeftOperand],              &[0]  );
+        expect_node_match(crumbs![Operator],                 &[1]  );
+        expect_node_match(crumbs![RightOperand],             &[2]  );
+        expect_node_match(crumbs![LeftOperand,LeftOperand],  &[0,0]);
+        expect_node_match(crumbs![LeftOperand,Operator],     &[0,1]);
+        expect_node_match(crumbs![LeftOperand,RightOperand], &[0,2]);
+
+        expect_node_mismatch(crumbs![Arg]);
+        // expect_node_mismatch(crumbs![LeftOperand,Arg]         );
+        // expect_node_mismatch(crumbs![RightOperand,LeftOperand]);
+        //
+        // expect_node_mismatch(crumbs![Arg]                     );
+        // expect_node_mismatch(crumbs![LeftOperand,Arg]         );
+        // expect_node_mismatch(crumbs![RightOperand,LeftOperand]);
+
+        // assert!(tree.convert_to_ast_crumbs(vec![1,5]).is_none());
+        // assert!(tree.convert_to_ast_crumbs(vec![0,0,0]).is_none());
     }
 }

--- a/src/rust/ide/span-tree/src/lib.rs
+++ b/src/rust/ide/span-tree/src/lib.rs
@@ -46,42 +46,6 @@ pub mod prelude {
 use prelude::*;
 
 
-// ==============
-// === Crumbs ===
-// ==============
-
-/// A possible connection endpoint described by span tree crumbs and ast crumbs.
-///
-/// In case that endpoint is the span tree node, ast crumbs are empty. Otherwise, they are relative
-/// to the AST corresponding to the span tree node.
-#[derive(Clone,Debug,Default,PartialEq,PartialOrd)]
-pub struct SplitCrumbs {
-    /// Crumbs to a Span Tree leaf.
-    pub head : Vec<usize>,
-    /// Crumbs for traversing AST corresponding to the span tree leaf.
-    /// Might be empty, if the span tree node corresponds to the desired AST node.
-    pub tail : ast::Crumbs,
-}
-
-impl SplitCrumbs {
-    pub fn new
-    (span_crumbs:impl IntoIterator<Item=usize>, ast_crumbs:impl ast::crumbs::IntoCrumbs)
-     -> SplitCrumbs {
-        SplitCrumbs {
-            head : span_crumbs.into_iter().collect(),
-            tail : ast_crumbs.into_crumbs(),
-        }
-    }
-
-    pub fn new_span(span_crumbs:impl IntoIterator<Item=usize>) -> SplitCrumbs {
-        SplitCrumbs {
-            head : span_crumbs.into_iter().collect(),
-            tail : default(),
-        }
-    }
-}
-
-
 
 // ================
 // === SpanTree ===
@@ -111,78 +75,5 @@ impl SpanTree {
             crumbs     : default(),
             ast_crumbs : default()
         }
-    }
-
-    /// Converts `Ast` crumbs to `SpanTree` crumbs.
-    ///
-    /// Interestingly, this never fails. At worst none of the Ast crumbs will be matched and all
-    /// will be placed in the `tail` part of or the `SplitCrumbs`.
-    pub fn convert_from_ast_crumbs(&self, ast_crumbs:&[ast::Crumb]) -> SplitCrumbs {
-        self.root.convert_from_ast_crumbs(ast_crumbs)
-    }
-
-    /// Converts `SpanTree` crumbs to `Ast` crumbs.
-    pub fn convert_to_ast_crumbs(&self, crumbs:SplitCrumbs) -> Option<ast::Crumbs> {
-        let root = self.root_ref();
-        let node_ref = root.traverse_subnode(crumbs.head.iter().copied())?;
-        let mut ret = node_ref.ast_crumbs;
-        ret.extend(crumbs.tail);
-        Some(ret)
-    }
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-    use ast::crumbs;
-
-    #[test]
-    fn crumb_conversion_test() {
-        let code = "1 + 2 + 3";
-        let ast  = parser::Parser::new_or_panic().parse_line(code).unwrap();
-        let tree = SpanTree::new(&ast).unwrap();
-
-        use ast::crumbs::InfixCrumb::*;
-        use ast::crumbs::PrefixCrumb::*;
-
-        let test_conversions0 = |ast_crumbs:ast::Crumbs, crumbs:SplitCrumbs| {
-            assert_eq!(tree.convert_from_ast_crumbs(&ast_crumbs), crumbs);
-            assert_eq!(tree.convert_to_ast_crumbs(crumbs).as_ref(), Some(&ast_crumbs));
-        };
-
-        // Tester to be used when the crumb refers to span tree node.
-        let expect_node_match = |ast_crumbs:ast::Crumbs, crumbs:&[usize]| {
-            let split_crumbs = SplitCrumbs::new_span(crumbs.iter().copied());
-            test_conversions0(ast_crumbs,split_crumbs)
-        };
-
-        let sub_node_match = |ast_crumbs:ast::Crumbs, head:&[usize], tail:ast::Crumbs| {
-            let split_crumbs = SplitCrumbs::new(head.iter().copied(),tail);
-            test_conversions0(ast_crumbs,split_crumbs)
-        };
-
-        let expect_node_mismatch = |ast_crumbs:ast::Crumbs| {
-            let split_crumbs = SplitCrumbs::new(vec![],ast_crumbs.iter().cloned());
-            test_conversions0(ast_crumbs,split_crumbs)
-        };
-
-        expect_node_match(crumbs![],                         &[]   );
-        expect_node_match(crumbs![LeftOperand],              &[0]  );
-        expect_node_match(crumbs![Operator],                 &[1]  );
-        expect_node_match(crumbs![RightOperand],             &[2]  );
-        expect_node_match(crumbs![LeftOperand,LeftOperand],  &[0,0]);
-        expect_node_match(crumbs![LeftOperand,Operator],     &[0,1]);
-        expect_node_match(crumbs![LeftOperand,RightOperand], &[0,2]);
-
-        expect_node_mismatch(crumbs![Arg]);
-        // expect_node_mismatch(crumbs![LeftOperand,Arg]         );
-        // expect_node_mismatch(crumbs![RightOperand,LeftOperand]);
-        //
-        // expect_node_mismatch(crumbs![Arg]                     );
-        // expect_node_mismatch(crumbs![LeftOperand,Arg]         );
-        // expect_node_mismatch(crumbs![RightOperand,LeftOperand]);
-
-        // assert!(tree.convert_to_ast_crumbs(vec![1,5]).is_none());
-        // assert!(tree.convert_to_ast_crumbs(vec![0,0,0]).is_none());
     }
 }

--- a/src/rust/ide/span-tree/src/node.rs
+++ b/src/rust/ide/span-tree/src/node.rs
@@ -56,7 +56,7 @@ pub trait Crumbs = IntoIterator<Item=usize>;
 ///
 /// Each node in SpanTree is bound to some span of code, and potentially may have corresponding
 /// AST node.
-#[derive(Debug,Eq,PartialEq)]
+#[derive(Clone,Debug,Eq,PartialEq)]
 #[allow(missing_docs)]
 pub struct Node {
     pub kind     : Kind,
@@ -84,37 +84,29 @@ impl Node {
 
     /// Function that converts from `Ast` crumbs into `SpanTree` crumbs.
     ///
-    /// `ast_crumbs` is an iterator that yields the crumbs to convert.
+    /// `ast_crumbs` is a slice with crumbs to be converted.
     /// `crumbs_so_far` is a list of previously converted crumbs which will be prepended to the
     /// returned result.
-    pub fn convert_crumbs(&self, mut ast_crumbs:impl Iterator<Item=ast::crumbs::Crumb>, mut crumbs_so_far:Vec<usize>) -> Option<Vec<usize>> {
-        if let Some(first_ast_crumb) = ast_crumbs.next() {
-            for (index,child) in self.children.iter().enumerate() {
-                let mut child_ast_crumbs = child.ast_crumbs.iter();
-                // Ignore non-matching children.
-                if child_ast_crumbs.next() == Some(&first_ast_crumb) {
-                    // If first crumb of the child matches, all others must match. Otherwise the
-                    // whole operation is a failure. We need to consume all matching ast crumbs.
-                    while let Some(child_ast_crumb) = child_ast_crumbs.next() {
-                        if Some(child_ast_crumb) != ast_crumbs.next().as_ref() {
-                            return None;
-                        }
-                    }
-                    crumbs_so_far.push(index);
-                    return child.node.convert_crumbs(ast_crumbs,crumbs_so_far);
-                }
-            }
-            // No matching child.
-            None
-        } else {
+    pub fn convert_crumbs
+    (&self, ast_crumbs:&[ast::Crumb], mut crumbs_so_far:Vec<usize>) -> Option<Vec<usize>> {
+        let is_matching = |child:&&Child| {
+            ast_crumbs.get(..child.ast_crumbs.len()).contains(&child.ast_crumbs)
+        };
+
+        if ast_crumbs.is_empty() {
             Some(crumbs_so_far)
+        } else if let Some((index, child)) = self.children.iter().find_position(is_matching) {
+            crumbs_so_far.push(index);
+            child.node.convert_crumbs(&ast_crumbs[child.ast_crumbs.len()..],crumbs_so_far)
+        } else {
+            None
         }
     }
 }
 
 /// A structure which contains `Node` being a child of some parent. It contains some additional
 /// data regarding this relation
-#[derive(Debug,Eq,PartialEq)]
+#[derive(Clone,Debug,Eq,PartialEq)]
 pub struct Child {
     /// A child node.
     pub node                : Node,

--- a/src/rust/ide/span-tree/src/node.rs
+++ b/src/rust/ide/span-tree/src/node.rs
@@ -14,6 +14,8 @@ use crate::SplitCrumbs;
 // === Helper Types ===
 // ====================
 
+// === Kind ===
+
 /// An enum describing kind of node.
 #[derive(Copy,Clone,Debug,Eq,PartialEq)]
 pub enum Kind {
@@ -44,11 +46,21 @@ pub enum Kind {
 #[derive(Copy,Clone,Debug,Eq,PartialEq)]
 pub enum InsertType {BeforeTarget,AfterTarget,Append}
 
+
+// === Crumbs ===
+
+pub type Crumb = usize;
+
 /// A type which identifies some node in SpanTree. This is essentially a iterator over child
 /// indices, so `[4]` means _root's fifth child_, `[4, 2]`means _the third child of root's fifth
 /// child_ and so on.
-pub trait Crumbs = IntoIterator<Item=usize>;
+pub trait Crumbs = IntoIterator<IntoIter:DoubleEndedIterator, Item=usize>;
 
+/// Convert crumbs to crumbs pointing to a parent.
+pub fn parent_crumbs(crumbs:impl Crumbs) -> Option<impl Crumbs> {
+    let mut iter = crumbs.into_iter();
+    iter.next_back().map(|_| iter)
+}
 
 // === Node ===
 

--- a/src/rust/ide/span-tree/src/node.rs
+++ b/src/rust/ide/span-tree/src/node.rs
@@ -7,7 +7,7 @@ use crate::iter::TreeFragment;
 
 use data::text::Index;
 use data::text::Size;
-
+use crate::SplitCrumbs;
 
 
 // ====================
@@ -83,11 +83,7 @@ impl Node {
     }
 
     /// Function that converts from `Ast` crumbs into `SpanTree` crumbs.
-    ///
-    /// `ast_crumbs` is a slice with crumbs to be converted.
-    /// `crumbs_so_far` is a list of previously converted crumbs which will be prepended to the
-    /// returned result.
-    pub fn convert_from_ast_crumbs(&self, mut ast_crumbs:&[ast::Crumb]) -> Option<Vec<usize>> {
+    pub fn convert_from_ast_crumbs(&self, mut ast_crumbs:&[ast::Crumb]) -> SplitCrumbs {
         let mut ret = Vec::new();
         let mut node = self;
         'crumbs: while ast_crumbs.len() > 0 {
@@ -100,32 +96,16 @@ impl Node {
                     continue 'crumbs;
                 }
             }
-            return None
+            // No matching child.
+            return SplitCrumbs {
+                head : ret,
+                tail : ast::Crumbs::from(ast_crumbs),
+            }
         }
-        Some(ret)
-        // let is_matching = |child:&&Child| {
-        //     ast_crumbs.get(..child.ast_crumbs.len()).contains(&child.ast_crumbs)
-        // };
-        //
-        // if ast_crumbs.is_empty() {
-        //     Some(crumbs_so_far)
-        // } else if let Some((index, child)) = self.children.iter().find_position(is_matching) {
-        //     crumbs_so_far.push(index);
-        //     child.node.convert_from_ast_crumbs(&ast_crumbs[child.ast_crumbs.len()..], crumbs_so_far)
-        // } else {
-        //     None
-        // }
-    }
-
-    pub fn convert_to_ast_crumbs(&self, crumbs:&[crate::Crumb]) -> Option<ast::Crumbs> {
-        let mut ret  = ast::Crumbs::new();
-        let mut node = self;
-        for crumb in crumbs {
-            let child = node.children.get(*crumb)?;
-            ret.extend(&child.ast_crumbs);
-            node = &child.node;
+        SplitCrumbs {
+            head : ret,
+            tail : default(),
         }
-        Some(ret)
     }
 }
 

--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -244,8 +244,8 @@ pub fn name_for_ast(ast:&Ast) -> String {
             }.into()
         }
         _ => {
-            if let Some(infix) = ast::opr::GeneralizedInfix::try_new_root(ast) {
-                name_for_ast(infix.opr.item.ast())
+            if let Some(infix) = ast::opr::GeneralizedInfix::try_new(ast) {
+                name_for_ast(infix.opr.ast())
             } else if let Some(prefix) = ast::prefix::Chain::try_new(ast) {
                 name_for_ast(&prefix.func)
             } else {
@@ -458,8 +458,8 @@ impl Handle {
                 destination_port.set(destination_ast,placeholder)
             }
         } else {
-            let crumbs = destination_port.ast_crumbs.iter().chain(connection.destination.crumbs.tail.iter()).collect_vec();
-            destination_ast.set_traversing(crumbs,placeholder)
+            let crumbs = destination_port.ast_crumbs.iter().chain(connection.destination.crumbs.tail.iter()).cloned().collect_vec();
+            destination_ast.set_traversing(&crumbs,placeholder)
         }?;
 
         self.set_expression_ast(destination_node.id(),replaced_destination)
@@ -943,12 +943,10 @@ main =
     #[wasm_bindgen_test]
     fn disconnect() {
         let mut test  = GraphControllerFixture::set_up();
-        const PROGRAM:&str = r"
-main =
+        const PROGRAM:&str = r"main =
     from = 3 + 4
     to   = foo from";
-        const EXPECTED:&str = r"
-main =
+        const EXPECTED:&str = r"main =
     from = 3 + 4
     to   = foo x";
         test.run_graph_for_main(PROGRAM, "main", |_, graph| async move {

--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -12,7 +12,7 @@ pub use crate::double_representation::graph::Id;
 use crate::double_representation::graph::GraphInfo;
 pub use crate::double_representation::graph::LocationHint;
 use crate::double_representation::node;
-// use crate::double_representation::node::NodeInfo;
+use crate::double_representation::node::NodeInfo;
 use crate::model::module::NodeMetadata;
 use crate::notification;
 
@@ -20,7 +20,6 @@ use parser::Parser;
 use span_tree::action::Actions;
 use span_tree::action::Action;
 use span_tree::SpanTree;
-use crate::double_representation::node::NodeInfo;
 use ast::crumbs::InfixCrumb;
 
 
@@ -411,6 +410,7 @@ impl Handle {
         Ok(name)
     }
 
+    // TODO[ao] Clean up the code and make it conform the coding guidelines.
     /// Create connection in graph.
     pub fn connect(&self, connection:&Connection) -> FallibleResult<()> {
 
@@ -440,6 +440,7 @@ impl Handle {
         self.set_expression_ast(destination_node.id(),new_expression)
     }
 
+    // TODO[ao] Clean up the code and make it conform the coding guidelines.
     /// Remove the connections from the graph.
     pub fn disconnect(&self, connection:&Connection) -> FallibleResult<()> {
         let destination_node = self.node_info(connection.destination.node)?;

--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -234,6 +234,12 @@ impl Connections {
 // === Utilities ===
 // =================
 
+/// Suggests a variable name for storing results of the given expression.
+///
+/// Name will try to express result of an infix operation (`sum` for `a+b`), kind of literal
+/// (`number` for `5`) and target function name for prefix chain.
+///
+/// The generated name is not unique and might collide with already present identifiers.
 pub fn name_for_ast(ast:&Ast) -> String {
     use ast::*;
     match ast.shape() {

--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -166,7 +166,7 @@ impl NodeTrees {
         if let Some(outputs) = self.outputs.as_ref() {
             // Node in assignment form. First crumb decides which span tree to use.
             let tree = match ast_crumbs.get(0) {
-                Some(ast::crumbs::Crumb::Infix(InfixCrumb::LeftOperand)) => outputs,
+                Some(ast::crumbs::Crumb::Infix(InfixCrumb::LeftOperand))  => outputs,
                 Some(ast::crumbs::Crumb::Infix(InfixCrumb::RightOperand)) => &self.inputs,
                 _ => return None,
             };
@@ -212,9 +212,9 @@ impl Connections {
         let tree = self.trees.get(&endpoint.node)?;
         let span_tree_node = tree.get_span_tree_node(&endpoint.crumbs)?;
         Some(Endpoint{
-            node           : endpoint.node,
-            port: span_tree_node.node.crumbs,
-            var_crumbs     : span_tree_node.ast_crumbs.into(),
+            node       : endpoint.node,
+            port       : span_tree_node.node.crumbs,
+            var_crumbs : span_tree_node.ast_crumbs.into(),
         })
     }
 
@@ -379,6 +379,7 @@ impl Handle {
             idents.extend(usage.used.into_iter());
             Ok(idents)
         } else {
+            // TODO[mwu] Even if definition is not a block, it still may use name from outside.
             Ok(vec![])
         }
     }
@@ -395,11 +396,7 @@ impl Handle {
             let candidate              = NormalizedName::new(iformat!("{base_name}{i}"));
             let available              = !unavailable.contains(&candidate);
             available.and_option_from(|| Some(candidate.deref().clone()))
-        });
-        let name = name.unwrap_or_else(|| {
-            let u = uuid::Uuid::new_v4();
-            iformat!("var_{u.to_simple()}")
-        });
+        }).unwrap(); // It always return a value.
         Ok(ast::known::Var::new(ast::Var {name}, None))
     }
 

--- a/src/rust/ide/src/controller/graph.rs
+++ b/src/rust/ide/src/controller/graph.rs
@@ -162,7 +162,8 @@ impl NodeTrees {
     /// Converts AST crumbs (as obtained from double rep's connection endpoint) into the span-tree
     /// crumbs.
     pub fn get_span_tree_node<'a,'b>
-    (&'a self, ast_crumbs:&'b ast::Crumbs) -> Option<span_tree::node::NodeFoundByAstCrumbs<'a,'b>> {
+    (&'a self, ast_crumbs:&'b [ast::Crumb])
+    -> Option<span_tree::node::NodeFoundByAstCrumbs<'a,'b>> {
         if let Some(outputs) = self.outputs.as_ref() {
             // Node in assignment form. First crumb decides which span tree to use.
             let tree = match ast_crumbs.get(0) {
@@ -373,7 +374,7 @@ impl Handle {
     /// resolution in the code in this graph.
     pub fn used_names(&self) -> FallibleResult<Vec<LocatedName>> {
         let def    = self.graph_definition_info()?;
-        if let Some(block)  = ast::known::Block::try_from(def.body()).ok() {
+        if let Ok(block)  = ast::known::Block::try_from(def.body()) {
             let usage  = double_representation::alias_analysis::analyse_block(&block);
             let mut idents = usage.introduced;
             idents.extend(usage.used.into_iter());

--- a/src/rust/ide/src/double_representation/alias_analysis.rs
+++ b/src/rust/ide/src/double_representation/alias_analysis.rs
@@ -42,6 +42,7 @@ impl NormalizedName {
         ast::identifier::name(ast).map(NormalizedName::new)
     }
 
+    /// Is the given string a prefix of this name.
     pub fn starts_with(&self, name:impl Str) -> bool {
         let prefix = NormalizedName::new(name);
         self.0.starts_with(prefix.0.as_str())

--- a/src/rust/ide/src/double_representation/alias_analysis.rs
+++ b/src/rust/ide/src/double_representation/alias_analysis.rs
@@ -27,6 +27,7 @@ pub type LocatedName = Located<NormalizedName>;
 /// The identifier name normalized to a lower-case (as the comparisons are case-insensitive).
 /// Implements case-insensitive compare with AST.
 #[derive(Clone,Debug,Display,Hash,PartialEq,Eq)]
+#[derive(Shrinkwrap)]
 pub struct NormalizedName(String);
 
 impl NormalizedName {
@@ -39,6 +40,11 @@ impl NormalizedName {
     /// If the given AST is an identifier, returns its normalized name.
     pub fn try_from_ast(ast:&Ast) -> Option<NormalizedName> {
         ast::identifier::name(ast).map(NormalizedName::new)
+    }
+
+    pub fn starts_with(&self, name:impl Str) -> bool {
+        let prefix = NormalizedName::new(name);
+        self.0.starts_with(prefix.0.as_str())
     }
 }
 

--- a/src/rust/ide/src/double_representation/alias_analysis/test_utils.rs
+++ b/src/rust/ide/src/double_representation/alias_analysis/test_utils.rs
@@ -137,7 +137,7 @@ impl<'a> IdentifierValidator<'a> {
     /// Marks given identifier as checked.
     pub fn validate_identifier(&mut self, name:&NormalizedName) {
         let err  = iformat!("{self.name}: unexpected identifier `{name}` validated");
-        let used = self.validations.get_mut(&name).expect(&err);
+        let used = self.validations.get_mut(name).expect(&err);
         *used = HasBeenValidated::Yes;
     }
 

--- a/src/rust/ide/src/double_representation/connection.rs
+++ b/src/rust/ide/src/double_representation/connection.rs
@@ -113,7 +113,6 @@ mod tests {
     use crate::double_representation::definition::DefinitionInfo;
     use crate::double_representation::graph::GraphInfo;
     use ast::crumbs;
-    use ast::crumbs::Crumb;
     use ast::crumbs::InfixCrumb;
 
     struct TestRun {

--- a/src/rust/ide/src/double_representation/connection.rs
+++ b/src/rust/ide/src/double_representation/connection.rs
@@ -77,7 +77,7 @@ pub fn list_block(block:&ast::Block<Ast>) -> Vec<Connection> {
     identifiers.used.into_iter().flat_map(|name| {
         // If name is both introduced and used in the graph's scope; and both of these occurrences
         // can be represented as endpoints, then we have a connection.
-        let source      = introduced_names.get(&name).cloned()?;
+        let source      = introduced_names.get(&name.item).cloned()?;
         let destination = Endpoint::new_in_block(block,name.crumbs)?;
         Some(Connection {source,destination})
     }).collect()

--- a/src/rust/ide/src/double_representation/definition.rs
+++ b/src/rust/ide/src/double_representation/definition.rs
@@ -165,6 +165,7 @@ impl DefinitionName {
             None => {
                 let name = match ast.shape() {
                     ast::Shape::Var         (var)   => Some(&var.name),
+                    ast::Shape::Cons        (var)   => Some(&var.name),
                     ast::Shape::Opr         (opr)   => Some(&opr.name),
                     ast::Shape::SectionSides(sides) => ast::identifier::name(&sides.opr),
                     // Shape::Cons is intentionally omitted.

--- a/src/rust/ide/src/double_representation/definition.rs
+++ b/src/rust/ide/src/double_representation/definition.rs
@@ -165,7 +165,6 @@ impl DefinitionName {
             None => {
                 let name = match ast.shape() {
                     ast::Shape::Var         (var)   => Some(&var.name),
-                    ast::Shape::Cons        (var)   => Some(&var.name),
                     ast::Shape::Opr         (opr)   => Some(&opr.name),
                     ast::Shape::SectionSides(sides) => ast::identifier::name(&sides.opr),
                     // Shape::Cons is intentionally omitted.

--- a/src/rust/ide/src/double_representation/node.rs
+++ b/src/rust/ide/src/double_representation/node.rs
@@ -3,9 +3,9 @@
 use crate::prelude::*;
 
 use ast::Ast;
-use ast::crumbs::Crumbable;
+use ast::crumbs::{Crumbable, InfixCrumb};
 use ast::known;
-
+use ast::opr::predefined::ASSIGNMENT;
 /// Node Id is the Ast Id attached to the node's expression.
 pub type Id = ast::Id;
 
@@ -104,6 +104,34 @@ impl NodeInfo {
             NodeInfo::Expression{ast}   => ast,
         }
     }
+
+    pub fn set_pattern(&mut self, pattern:Ast) {
+        let id = self.id();
+        match self {
+            NodeInfo::Binding {infix} => {
+                // Setting infix operand never fails.
+                infix.update_shape(|infix| infix.larg = pattern)
+            }
+            NodeInfo::Expression {ast} => {
+                let infix = ast::Infix {
+                    larg : pattern,
+                    loff : 1,
+                    opr  : Ast::opr("="),
+                    roff : 1,
+                    rarg : ast.clone(),
+                };
+                let infix = known::Infix::new(infix, None);
+                *self = NodeInfo::Binding {infix};
+            }
+        }
+
+    }
+}
+
+impl ast::HasTokens for NodeInfo {
+    fn feed_to(&self, consumer:&mut impl ast::TokenConsumer) {
+        self.ast().feed_to(consumer)
+    }
 }
 
 
@@ -162,11 +190,39 @@ mod tests {
         let id = Id::new_v4();
         let number = ast::Number { base:None, int: "4".into()};
         let larg   = Ast::var("foo");
-        let loff   = 1;
-        let opr    = Ast::opr("=");
-        let roff   = 1;
         let rarg   = Ast::new(number, Some(id));
-        let ast    = Ast::new(ast::Infix {larg,loff,opr,roff,rarg}, None);
+        let ast    = Ast::infix(larg,ASSIGNMENT,rarg);
         expect_node(ast,"4",id);
+    }
+
+    #[test]
+    fn setting_pattern_on_expression_node_test() {
+        let id       = uuid::Uuid::new_v4();
+        let line_ast = Ast::number(2).with_id(id);
+        let mut node = NodeInfo::from_line_ast(&line_ast).unwrap();
+        assert_eq!(node.repr(), "2");
+        assert_eq!(node.id(),id);
+
+        node.set_pattern(Ast::var("foo"));
+
+        assert_eq!(node.repr(), "foo = 2");
+        assert_eq!(node.id(),id);
+    }
+
+    #[test]
+    fn setting_pattern_on_binding_node_test() {
+        let id       = uuid::Uuid::new_v4();
+        let larg     = Ast::var("foo");
+        let rarg     = Ast::var("bar").with_id(id);
+        let line_ast = Ast::infix(larg,ASSIGNMENT,rarg);
+        let mut node = NodeInfo::from_line_ast(&line_ast).unwrap();
+
+        assert_eq!(node.repr(), "foo = bar");
+        assert_eq!(node.id(),id);
+
+        node.set_pattern(Ast::var("baz"));
+
+        assert_eq!(node.repr(), "baz = bar");
+        assert_eq!(node.id(),id);
     }
 }

--- a/src/rust/ide/src/double_representation/node.rs
+++ b/src/rust/ide/src/double_representation/node.rs
@@ -81,7 +81,7 @@ impl NodeInfo {
     pub fn pattern(&self) -> Option<&Ast> {
         match self {
             NodeInfo::Binding   {infix} => Some(&infix.larg),
-            NodeInfo::Expression{ast}   => None,
+            NodeInfo::Expression{..}    => None,
         }
     }
 

--- a/src/rust/ide/src/double_representation/node.rs
+++ b/src/rust/ide/src/double_representation/node.rs
@@ -77,6 +77,14 @@ impl NodeInfo {
         }
     }
 
+    /// AST of the node's pattern (assignment's left-hand side).
+    pub fn pattern(&self) -> Option<&Ast> {
+        match self {
+            NodeInfo::Binding   {infix} => Some(&infix.larg),
+            NodeInfo::Expression{ast}   => None,
+        }
+    }
+
     /// Mutable AST of the node's expression. Maintains ID.
     pub fn set_expression(&mut self, expression:Ast) {
         let id = self.id();

--- a/src/rust/ide/src/double_representation/node.rs
+++ b/src/rust/ide/src/double_representation/node.rs
@@ -3,9 +3,8 @@
 use crate::prelude::*;
 
 use ast::Ast;
-use ast::crumbs::{Crumbable, InfixCrumb};
+use ast::crumbs::Crumbable;
 use ast::known;
-use ast::opr::predefined::ASSIGNMENT;
 /// Node Id is the Ast Id attached to the node's expression.
 pub type Id = ast::Id;
 
@@ -105,8 +104,9 @@ impl NodeInfo {
         }
     }
 
+    /// Set the pattern (left side of assignment) for node. If it is an Expression node, the
+    /// assignment infix will be introduced.
     pub fn set_pattern(&mut self, pattern:Ast) {
-        let id = self.id();
         match self {
             NodeInfo::Binding {infix} => {
                 // Setting infix operand never fails.
@@ -143,6 +143,8 @@ impl ast::HasTokens for NodeInfo {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    use ast::opr::predefined::ASSIGNMENT;
 
     fn expect_node(ast:Ast, expression_text:&str, id:Id) {
         let node_info = NodeInfo::from_line_ast(&ast).expect("expected a node");


### PR DESCRIPTION
### Pull Request Description
This introduces operations on connections to the graph controller. This required additionally to implement searching for free variable name and changing expression node (like `2+2`) to assignment nodes (like `sum = 2 + 2`).

### Important Notes
* Due to harsh timelines, there are some functions which needs to be refactored and does not conform to coding guidelines. That will be fixed in one of the next PRs.


### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [ ] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

