### PR TITLE
Generating SpanTree from macros

### DIFF
--- a/src/rust/ide/ast/impl/src/crumbs.rs
+++ b/src/rust/ide/ast/impl/src/crumbs.rs
@@ -324,8 +324,8 @@ pub enum SegmentMatchCrumb {
 #[allow(missing_docs)]
 #[derive(Clone,Debug,PartialEq,Eq,Hash,PartialOrd,Ord)]
 pub struct AmbiguousCrumb {
-    index : usize,
-    field : AmbiguousSegmentCrumb,
+    pub index : usize,
+    pub field : AmbiguousSegmentCrumb,
 }
 
 #[allow(missing_docs)]

--- a/src/rust/ide/ast/impl/src/lib.rs
+++ b/src/rust/ide/ast/impl/src/lib.rs
@@ -90,7 +90,7 @@ pub struct WrongEnum {pub expected_con:String}
 // === Tree ===
 // ============
 
-/// A tree structure where each node may store value of `K` and has arbitrary
+/// A tree structure where each node may store value of `V` and has arbitrary
 /// number of children nodes, each marked with a single `K`.
 ///
 /// It is used to describe ambiguous macro match.

--- a/src/rust/ide/span-tree/src/action.rs
+++ b/src/rust/ide/span-tree/src/action.rs
@@ -233,46 +233,52 @@ mod test {
 
         let cases:&[Case] = &
             // Setting
-            [ Case{expr:"a + b"    , span:0..5, action:Set  , expected:"foo"            }
-            , Case{expr:"a + b"    , span:0..1, action:Set  , expected:"foo + b"        }
-            , Case{expr:"a + b"    , span:4..5, action:Set  , expected:"a + foo"        }
-            , Case{expr:"a + b + c", span:0..1, action:Set  , expected:"foo + b + c"    }
-            , Case{expr:"a + b + c", span:4..5, action:Set  , expected:"a + foo + c"    }
-            , Case{expr:"a , b , c", span:0..1, action:Set  , expected:"foo , b , c"    }
-            , Case{expr:"a , b , c", span:4..5, action:Set  , expected:"a , foo , c"    }
-            , Case{expr:"a , b , c", span:8..9, action:Set  , expected:"a , b , foo"    }
-            , Case{expr:"f a b"    , span:0..1, action:Set  , expected:"foo a b"        }
-            , Case{expr:"f a b"    , span:2..3, action:Set  , expected:"f foo b"        }
-            , Case{expr:"f a b"    , span:4..5, action:Set  , expected:"f a foo"        }
-            , Case{expr:"+ b"      , span:0..0, action:Set  , expected:"foo + b"        }
-            , Case{expr:"+ b"      , span:2..3, action:Set  , expected:"+ foo"          }
-            , Case{expr:"a +"      , span:0..1, action:Set  , expected:"foo +"          }
-            , Case{expr:"a +"      , span:3..3, action:Set  , expected:"a + foo"        }
-            , Case{expr:"+"        , span:0..0, action:Set  , expected:"foo +"          }
-            , Case{expr:"+"        , span:1..1, action:Set  , expected:"+ foo"          }
-            , Case{expr:"a + b"    , span:0..0, action:Set  , expected:"foo + a + b"    }
-            , Case{expr:"a + b"    , span:1..1, action:Set  , expected:"a + foo + b"    }
-            , Case{expr:"a + b"    , span:5..5, action:Set  , expected:"a + b + foo"    }
-            , Case{expr:"+ b"      , span:3..3, action:Set  , expected:"+ b + foo"      }
-            , Case{expr:"a + b + c", span:0..0, action:Set  , expected:"foo + a + b + c"}
-            , Case{expr:"a + b + c", span:5..5, action:Set  , expected:"a + b + foo + c"}
-            , Case{expr:"a , b , c", span:0..0, action:Set  , expected:"foo , a , b , c"}
-            , Case{expr:"a , b , c", span:4..4, action:Set  , expected:"a , foo , b , c"}
-            , Case{expr:"a , b , c", span:8..8, action:Set  , expected:"a , b , foo , c"}
-            , Case{expr:"a , b , c", span:9..9, action:Set  , expected:"a , b , c , foo"}
-            , Case{expr:", b"      , span:3..3, action:Set  , expected:", b , foo"      }
-            , Case{expr:"f a b"    , span:2..2, action:Set  , expected:"f foo a b"      }
-            , Case{expr:"f a b"    , span:3..3, action:Set  , expected:"f a foo b"      }
-            , Case{expr:"f a b"    , span:5..5, action:Set  , expected:"f a b foo"      }
+            [ Case{expr:"a + b"      , span:0..5  , action:Set  , expected:"foo"            }
+            , Case{expr:"a + b"      , span:0..1  , action:Set  , expected:"foo + b"        }
+            , Case{expr:"a + b"      , span:4..5  , action:Set  , expected:"a + foo"        }
+            , Case{expr:"a + b + c"  , span:0..1  , action:Set  , expected:"foo + b + c"    }
+            , Case{expr:"a + b + c"  , span:4..5  , action:Set  , expected:"a + foo + c"    }
+            , Case{expr:"a , b , c"  , span:0..1  , action:Set  , expected:"foo , b , c"    }
+            , Case{expr:"a , b , c"  , span:4..5  , action:Set  , expected:"a , foo , c"    }
+            , Case{expr:"a , b , c"  , span:8..9  , action:Set  , expected:"a , b , foo"    }
+            , Case{expr:"f a b"      , span:0..1  , action:Set  , expected:"foo a b"        }
+            , Case{expr:"f a b"      , span:2..3  , action:Set  , expected:"f foo b"        }
+            , Case{expr:"f a b"      , span:4..5  , action:Set  , expected:"f a foo"        }
+            , Case{expr:"+ b"        , span:0..0  , action:Set  , expected:"foo + b"        }
+            , Case{expr:"+ b"        , span:2..3  , action:Set  , expected:"+ foo"          }
+            , Case{expr:"a +"        , span:0..1  , action:Set  , expected:"foo +"          }
+            , Case{expr:"a +"        , span:3..3  , action:Set  , expected:"a + foo"        }
+            , Case{expr:"+"          , span:0..0  , action:Set  , expected:"foo +"          }
+            , Case{expr:"+"          , span:1..1  , action:Set  , expected:"+ foo"          }
+            , Case{expr:"a + b"      , span:0..0  , action:Set  , expected:"foo + a + b"    }
+            , Case{expr:"a + b"      , span:1..1  , action:Set  , expected:"a + foo + b"    }
+            , Case{expr:"a + b"      , span:5..5  , action:Set  , expected:"a + b + foo"    }
+            , Case{expr:"+ b"        , span:3..3  , action:Set  , expected:"+ b + foo"      }
+            , Case{expr:"a + b + c"  , span:0..0  , action:Set  , expected:"foo + a + b + c"}
+            , Case{expr:"a + b + c"  , span:5..5  , action:Set  , expected:"a + b + foo + c"}
+            , Case{expr:"a , b , c"  , span:0..0  , action:Set  , expected:"foo , a , b , c"}
+            , Case{expr:"a , b , c"  , span:4..4  , action:Set  , expected:"a , foo , b , c"}
+            , Case{expr:"a , b , c"  , span:8..8  , action:Set  , expected:"a , b , foo , c"}
+            , Case{expr:"a , b , c"  , span:9..9  , action:Set  , expected:"a , b , c , foo"}
+            , Case{expr:", b"        , span:3..3  , action:Set  , expected:", b , foo"      }
+            , Case{expr:"f a b"      , span:2..2  , action:Set  , expected:"f foo a b"      }
+            , Case{expr:"f a b"      , span:3..3  , action:Set  , expected:"f a foo b"      }
+            , Case{expr:"f a b"      , span:5..5  , action:Set  , expected:"f a b foo"      }
+            , Case{expr:"if a then b", span:3..4  , action:Set  , expected: "if foo then b" }
+            , Case{expr:"if a then b", span:10..11, action:Set  , expected: "if a then foo" }
+            , Case{expr:"(a + b + c)", span:5..6  , action:Set  , expected: "(a + foo + c)" }
+            , Case{expr:"(a + b + c" , span:5..6  , action:Set  , expected: "(a + foo + c"  }
             // Erasing
-            , Case{expr:"a + b + c", span:0..1, action:Erase, expected:"b + c"          }
-            , Case{expr:"a + b + c", span:4..5, action:Erase, expected:"a + c"          }
-            , Case{expr:"a + b + c", span:8..9, action:Erase, expected:"a + b"          }
-            , Case{expr:"a , b , c", span:0..1, action:Erase, expected:"b , c"          }
-            , Case{expr:"a , b , c", span:4..5, action:Erase, expected:"a , c"          }
-            , Case{expr:"a , b , c", span:8..9, action:Erase, expected:"a , b"          }
-            , Case{expr:"f a b"    , span:2..3, action:Erase, expected:"f b"            }
-            , Case{expr:"f a b"    , span:4..5, action:Erase, expected:"f a"            }
+            , Case{expr:"a + b + c"  , span:0..1  , action:Erase, expected:"b + c"          }
+            , Case{expr:"a + b + c"  , span:4..5  , action:Erase, expected:"a + c"          }
+            , Case{expr:"a + b + c"  , span:8..9  , action:Erase, expected:"a + b"          }
+            , Case{expr:"a , b , c"  , span:0..1  , action:Erase, expected:"b , c"          }
+            , Case{expr:"a , b , c"  , span:4..5  , action:Erase, expected:"a , c"          }
+            , Case{expr:"a , b , c"  , span:8..9  , action:Erase, expected:"a , b"          }
+            , Case{expr:"f a b"      , span:2..3  , action:Erase, expected:"f b"            }
+            , Case{expr:"f a b"      , span:4..5  , action:Erase, expected:"f a"            }
+            , Case{expr:"(a + b + c)", span:5..6  , action:Erase, expected: "(a + c)"       }
+            , Case{expr:"(a + b + c" , span:5..6  , action:Erase, expected: "(a + c"        }
             ];
         let parser = Parser::new_or_panic();
         for case in cases { case.run(&parser); }
@@ -306,27 +312,32 @@ mod test {
             }
         }
         let cases:&[Case] = &
-            [ Case{expr:"abc"      , span:0..3, expected: &[Set]       }
-            , Case{expr:"a + b"    , span:0..0, expected: &[Set]       }
-            , Case{expr:"a + b"    , span:0..1, expected: &[Set] }
-            , Case{expr:"a + b"    , span:1..1, expected: &[Set]       }
-            , Case{expr:"a + b"    , span:2..3, expected: &[]          }
-            , Case{expr:"a + b"    , span:4..5, expected: &[Set] }
-            , Case{expr:"a + b"    , span:5..5, expected: &[Set]       }
-            , Case{expr:"a + b + c", span:0..0, expected: &[Set]       }
-            , Case{expr:"a + b + c", span:0..1, expected: &[Set,Erase] }
-            , Case{expr:"a + b + c", span:1..1, expected: &[Set]       }
-            , Case{expr:"a + b + c", span:4..5, expected: &[Set,Erase] }
-            , Case{expr:"a + b + c", span:5..5, expected: &[Set]       }
-            , Case{expr:"a + b + c", span:8..9, expected: &[Set,Erase] }
-            , Case{expr:"a + b + c", span:9..9, expected: &[Set]       }
-            , Case{expr:"f a b"    , span:0..1, expected: &[Set]       }
-            , Case{expr:"f a b"    , span:2..2, expected: &[Set]       }
-            , Case{expr:"f a b"    , span:2..3, expected: &[Set,Erase] }
-            , Case{expr:"f a b"    , span:3..3, expected: &[Set]       }
-            , Case{expr:"f a b"    , span:4..5, expected: &[Set,Erase] }
-            , Case{expr:"f a b"    , span:5..5, expected: &[Set]       }
-            , Case{expr:"f a"      , span:2..3, expected: &[Set]       }
+            [ Case{expr:"abc"        , span:0..3  , expected: &[Set]       }
+            , Case{expr:"a + b"      , span:0..0  , expected: &[Set]       }
+            , Case{expr:"a + b"      , span:0..1  , expected: &[Set]       }
+            , Case{expr:"a + b"      , span:1..1  , expected: &[Set]       }
+            , Case{expr:"a + b"      , span:2..3  , expected: &[]          }
+            , Case{expr:"a + b"      , span:4..5  , expected: &[Set]       }
+            , Case{expr:"a + b"      , span:5..5  , expected: &[Set]       }
+            , Case{expr:"a + b + c"  , span:0..0  , expected: &[Set]       }
+            , Case{expr:"a + b + c"  , span:0..1  , expected: &[Set,Erase] }
+            , Case{expr:"a + b + c"  , span:1..1  , expected: &[Set]       }
+            , Case{expr:"a + b + c"  , span:4..5  , expected: &[Set,Erase] }
+            , Case{expr:"a + b + c"  , span:5..5  , expected: &[Set]       }
+            , Case{expr:"a + b + c"  , span:8..9  , expected: &[Set,Erase] }
+            , Case{expr:"a + b + c"  , span:9..9  , expected: &[Set]       }
+            , Case{expr:"f a b"      , span:0..1  , expected: &[Set]       }
+            , Case{expr:"f a b"      , span:2..2  , expected: &[Set]       }
+            , Case{expr:"f a b"      , span:2..3  , expected: &[Set,Erase] }
+            , Case{expr:"f a b"      , span:3..3  , expected: &[Set]       }
+            , Case{expr:"f a b"      , span:4..5  , expected: &[Set,Erase] }
+            , Case{expr:"f a b"      , span:5..5  , expected: &[Set]       }
+            , Case{expr:"f a"        , span:2..3  , expected: &[Set]       }
+            , Case{expr:"if a then b", span:3..4  , expected: &[Set]       }
+            , Case{expr:"if a then b", span:10..11, expected: &[Set]       }
+            , Case{expr:"(a + b + c)", span:5..6  , expected: &[Set,Erase] }
+            , Case{expr:"(a"         , span:1..2  , expected: &[Set]       }
+            , Case{expr:"(a + b + c" , span:5..6  , expected: &[Set,Erase] }
             ];
         let parser = Parser::new_or_panic();
         for case in cases { case.run(&parser); }

--- a/src/rust/ide/span-tree/src/action.rs
+++ b/src/rust/ide/span-tree/src/action.rs
@@ -159,8 +159,8 @@ impl<'a> Implementation for node::Ref<'a> {
     fn erase_impl(&self) -> Option<EraseOperation> {
 
         match self.node.kind {
-            node::Kind::Argument{removable:true,..} |
-            node::Kind::Target  {removable:true}    => Some(Box::new(move |root| {
+            node::Kind::Argument{is_removable:true} |
+            node::Kind::Target  {is_removable:true} => Some(Box::new(move |root| {
                 let parent_crumb = &self.ast_crumbs[..self.ast_crumbs.len()-1];
                 let ast          = root.get_traversing(parent_crumb)?;
                 let new_ast = if let Some(mut infix) = ast::opr::Chain::try_new(ast) {

--- a/src/rust/ide/span-tree/src/generate.rs
+++ b/src/rust/ide/span-tree/src/generate.rs
@@ -219,10 +219,7 @@ impl SpanTreeGenerator for ast::Match<Ast> {
         let mut gen   = ChildGenerator::default();
         if let Some(pat) = &self.pfx {
             for macros::AstInPattern {ast,crumbs} in macros::all_ast_nodes_in_pattern(&pat) {
-                let located_ast = Located {
-                    crumbs : crumbs![ast::crumbs::MatchCrumb::Pfx{val:crumbs}],
-                    item   : ast.wrapped,
-                };
+                let located_ast = Located::new(ast::crumbs::MatchCrumb::Pfx {val:crumbs},ast.wrapped);
                 gen.generate_ast_node(located_ast,children_kind)?;
                 gen.spacing(ast.off);
             }

--- a/src/rust/ide/span-tree/src/generate.rs
+++ b/src/rust/ide/span-tree/src/generate.rs
@@ -3,13 +3,13 @@
 use crate::prelude::*;
 
 use crate::node;
-use crate::node::InsertType;
+use crate::node::{InsertType, Kind};
 use crate::Node;
 use crate::SpanTree;
 
-use ast::Ast;
+use ast::{Ast, Shifted, MacroPatternMatch};
 use ast::assoc::Assoc;
-use ast::crumbs::Located;
+use ast::crumbs::{Located, PatternMatchCrumb, MatchCrumb, SegmentMatchCrumb};
 use ast::HasLength;
 use ast::opr::GeneralizedInfix;
 use data::text::Size;
@@ -103,7 +103,8 @@ impl SpanTreeGenerator for Ast {
             match self.shape() {
                 ast::Shape::Prefix {..} =>
                     ast::prefix::Chain::try_new(self).unwrap().generate_node(kind),
-                // TODO[a] add other shapes, e.g. macros
+                // ast::Shape::Match(ast) =>
+                //     ast.generate_node(kind),
                 _  => Ok(Node {kind,
                     size     : Size::new(self.len()),
                     children : default(),
@@ -122,9 +123,8 @@ impl SpanTreeGenerator for ast::opr::Chain {
         // (target and two arguments).
         let removable       = self.args.len() >= 2;
         let node_and_offset = match &self.target {
-            Some(target) =>
-                target.arg.generate_node(node::Kind::Target {removable}).map(|n| (n,target.offset)),
-            None => Ok((Node::new_empty(InsertType::BeforeTarget),0)),
+            Some(sast) => sast.generate_node(node::Kind::Target {removable}).map(|n| (n,sast.off)),
+            None       => Ok((Node::new_empty(InsertType::BeforeTarget),0)),
         };
 
         // In this fold we pass last generated node and offset after it, wrapped in Result.
@@ -147,10 +147,10 @@ impl SpanTreeGenerator for ast::opr::Chain {
             if has_target { gen.generate_empty_node(InsertType::AfterTarget); }
             gen.spacing(off);
             gen.generate_ast_node(opr_ast,node::Kind::Operation)?;
-            if let Some(operand) = &elem.operand {
+            if let Some(sast) = &elem.operand {
                 let arg_crumbs = elem.crumb_to_operand(has_left);
-                let arg_ast    = Located::new(arg_crumbs,operand.arg.clone_ref());
-                gen.spacing(operand.offset);
+                let arg_ast    = Located::new(arg_crumbs,sast.wrapped.clone_ref());
+                gen.spacing(sast.off);
                 gen.generate_ast_node(arg_ast,node::Kind::Argument {removable})?;
             }
             gen.generate_empty_node(InsertType::Append);
@@ -199,6 +199,112 @@ impl SpanTreeGenerator for ast::prefix::Chain {
                 children : gen.children,
             })
         })
+    }
+}
+
+
+// === Macros ===
+
+struct MacroChild {
+    crumbs: Vec<PatternMatchCrumb>,
+    offset: Size,
+    ast: Ast,
+}
+
+/// Helper function that returns children for MacroPatternMatch.
+fn pattern_children(pat:&MacroPatternMatch<Shifted<Ast>>) -> Vec<MacroChild> {
+    use ast::MacroPatternMatchRaw::*;
+    use ast::crumbs::PatternMatchCrumb;
+
+    let mut patterns = vec![(vec![],pat)];
+    let mut children = vec![];
+    let mut offset   = Size{value:0};
+    let mut finish   = |ast,crumbs,crumb| {
+        crumbs.push(crumb);
+        offset += ast.off;
+        let child = MacroChild{crumbs,offset,ast};
+        offset += ast.wrapped.len();
+        children.push(child);
+    };
+    while let Some((mut crumb,pattern)) = patterns.pop() {
+        match pattern.deref() {
+            Begin(_)   => (),
+            End(_)     => (),
+            Nothing(_) => (),
+            Build(pat)   => finish(pat.elem,crumb,PatternMatchCrumb::Build),
+            Err(pat)     => finish(pat.elem,crumb,PatternMatchCrumb::Err),
+            Tok(pat)     => finish(pat.elem,crumb,PatternMatchCrumb::Tok),
+            Blank(pat)   => finish(pat.elem,crumb,PatternMatchCrumb::Blank),
+            Var(pat)     => finish(pat.elem,crumb,PatternMatchCrumb::Var),
+            Cons(pat)    => finish(pat.elem,crumb,PatternMatchCrumb::Cons),
+            Opr(pat)     => finish(pat.elem,crumb,PatternMatchCrumb::Opr),
+            Mod(pat)     => finish(pat.elem,crumb,PatternMatchCrumb::Mod),
+            Num(pat)     => finish(pat.elem,crumb,PatternMatchCrumb::Num),
+            Text(pat)    => finish(pat.elem,crumb,PatternMatchCrumb::Text),
+            Block(pat)   => finish(pat.elem,crumb,PatternMatchCrumb::Block),
+            Macro(pat)   => finish(pat.elem,crumb,PatternMatchCrumb::Macro),
+            Invalid(pat) => finish(pat.elem,crumb,PatternMatchCrumb::Invalid),
+            Except(pat) => {
+                crumb.push(PatternMatchCrumb::Except);
+                patterns.push((crumb,&pat.elem))
+            },
+            Tag(pat) => {
+                crumb.push(PatternMatchCrumb::Tag);
+                patterns.push((crumb,&pat.elem))
+            },
+            Cls(pat) => {
+                crumb.push(PatternMatchCrumb::Cls);
+                patterns.push((crumb,&pat.elem))
+            },
+            Or(pat) => {
+                crumb.push(PatternMatchCrumb::Or);
+                patterns.push((crumb,&pat.elem));
+            }
+            Seq(pat) => {
+                let mut crumb1 = crumb.clone();
+                let mut crumb2 = crumb.clone();
+                crumb1.push(PatternMatchCrumb::Seq{right:false});
+                crumb2.push(PatternMatchCrumb::Seq{right:true});
+                patterns.push((crumb2,&pat.elem.1));
+                patterns.push((crumb1,&pat.elem.0));
+            },
+            Many(pat) => {
+                for (index,pat) in pat.elem.iter().enumerate().rev() {
+                    let mut new_crumb = crumb.clone();
+                    new_crumb.push(PatternMatchCrumb::Many{index});
+                    patterns.push((new_crumb,pat));
+                }
+            }
+        }
+    }
+    children
+}
+
+impl SpanTreeGenerator for ast::Match<Ast> {
+    fn generate_node(&self, kind:Kind) -> FallibleResult<Node> {
+        let mut children = vec![];
+        if let Some(pat) = &self.pfx {
+            for MacroChild{crumbs,offset,ast} in pattern_children(&pat) {
+                let ast_crumbs = vec![MatchCrumb::Pfx{val:crumbs}.into()];
+                let node       = ast.generate_node(Kind::Macro)?;
+                children.push(node::Child{node,offset,ast_crumbs});
+            }
+        }
+        let mut off = children.last().map(|c|c.offset).unwrap_or_default();
+        for (index,seg) in self.segs.iter_shifted().enumerate() {
+            let ast_crumbs = vec![MatchCrumb::Segs{index,val:SegmentMatchCrumb::Head}.into()];
+            let node       = seg.wrapped.head.generate_node(Kind::Macro)?;
+            let offset     = off + seg.off;
+            children.push(node::Child{node,offset,ast_crumbs});
+            for MacroChild{crumbs,offset,ast} in pattern_children(&seg.body) {
+                let seg_crumb  = SegmentMatchCrumb::Body{val:crumbs};
+                let ast_crumbs = vec![MatchCrumb::Segs{index,val:seg_crumb}.into()];
+                let node       = ast.generate_node(Kind::Macro)?;
+                let offset     = off + seg.off + offset;
+                children.push(node::Child{node,offset,ast_crumbs});
+            }
+        }
+        Ok(Node{kind,size:default(),children})
     }
 }
 

--- a/src/rust/ide/span-tree/src/generate.rs
+++ b/src/rust/ide/span-tree/src/generate.rs
@@ -483,8 +483,8 @@ mod test {
         let tree = ast.generate_tree().unwrap();
         let removable = false;
 
-        let if_then_else_cr = vec![Seq { right: false }, Or, Build];
-        let parens_cr       = vec![Seq { right: false }, Or, Or, Build];
+        let if_then_else_cr = crumbs![Seq { right: false }, Or, Build];
+        let parens_cr       = crumbs![Seq { right: false }, Or, Or, Build];
         let segment_body_crumbs = |index:usize, pattern_crumb:&Vec<PatternMatchCrumb>| {
             let val = ast::crumbs::SegmentMatchCrumb::Body {val:pattern_crumb.clone()};
             vec![ast::crumbs::MatchCrumb::Segs {val,index}]

--- a/src/rust/ide/span-tree/src/generate/macros.rs
+++ b/src/rust/ide/span-tree/src/generate/macros.rs
@@ -1,5 +1,8 @@
 //! A module with utilities for generating SpanTree from macros (Match and Ambiguous).
 
+// TODO[ao] Duplicated with `pattern_subcrumbs` function in `ast::crumbs`, but adds information
+// about spacing. All the 'crumblike' utilities should be merged to one solution
+
 use crate::prelude::*;
 
 use ast::Ast;

--- a/src/rust/ide/span-tree/src/generate/macros.rs
+++ b/src/rust/ide/span-tree/src/generate/macros.rs
@@ -1,0 +1,139 @@
+//! A module with utilities for generating SpanTree from macros (Match and Ambiguous).
+
+use crate::prelude::*;
+
+use ast::Ast;
+use ast::MacroPatternMatch;
+use ast::Shifted;
+use ast::crumbs::PatternMatchCrumb;
+
+
+
+// ======================
+// === LocatedPattern ===
+// ======================
+
+/// A fragment of MacroPatternMatch localized by PatternMatchCrumbs.
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub struct LocatedPattern<'a> {
+    pub pattern : &'a MacroPatternMatch<Shifted<Ast>>,
+    pub crumbs  : Vec<PatternMatchCrumb>,
+}
+
+
+
+// ==================
+// === PatternDfs ===
+// ==================
+
+/// A iterator over all nodes in MacroPatternMatch tree, traversing it with DFS algorithm.
+struct PatternDfs<'a> {
+    /// The FILO queue of nodes to visit.
+    to_visit: Vec<LocatedPattern<'a>>
+}
+
+impl<'a> Iterator for PatternDfs<'a> {
+    type Item = LocatedPattern<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let to_return = self.to_visit.pop();
+        if let Some(pattern) = &to_return {
+            self.push_children_to_visit(pattern);
+        }
+        to_return
+    }
+}
+
+impl<'a> PatternDfs<'a> {
+    /// Create iterator which start from `root` node.
+    pub fn new(root:&'a MacroPatternMatch<Shifted<Ast>>) -> Self {
+        let first_to_visit = LocatedPattern {
+            pattern : root,
+            crumbs  : vec![],
+        };
+        PatternDfs {
+            to_visit: vec![first_to_visit],
+        }
+    }
+
+    /// Obtain all children of `pattern` and push them to `to_visit` queue.
+    fn push_children_to_visit(&mut self, pattern:&LocatedPattern<'a>) {
+        use ast::MacroPatternMatchRaw::*;
+        match pattern.pattern.deref() {
+            Except(pat) => self.push_child_to_visit(&pattern,&pat.elem,PatternMatchCrumb::Except),
+            Tag(pat)    => self.push_child_to_visit(&pattern,&pat.elem,PatternMatchCrumb::Tag),
+            Cls(pat)    => self.push_child_to_visit(&pattern,&pat.elem,PatternMatchCrumb::Cls),
+            Or(pat)     => self.push_child_to_visit(&pattern,&pat.elem,PatternMatchCrumb::Or),
+            Seq(pat)    => {
+                let (left_elem,right_elem) = &pat.elem;
+                self.push_child_to_visit(&pattern,left_elem ,PatternMatchCrumb::Seq{right:false});
+                self.push_child_to_visit(&pattern,right_elem,PatternMatchCrumb::Seq{right:true});
+            },
+            Many(pat) => {
+                for (index,elem) in pat.elem.iter().enumerate().rev() {
+                    self.push_child_to_visit(&pattern,elem,PatternMatchCrumb::Many {index});
+                }
+            }
+            // Other patterns does not have children.
+            _ => {}
+        }
+    }
+
+    fn push_child_to_visit
+    ( &mut self
+      , pattern : &LocatedPattern<'a>
+      , child   : &'a MacroPatternMatch<Shifted<Ast>>
+      , crumb   : PatternMatchCrumb
+    ) {
+        let loc_pattern = LocatedPattern {
+            pattern : child,
+            crumbs  : pattern.crumbs.iter().cloned().chain(std::iter::once(crumb)).collect()
+        };
+        self.to_visit.push(loc_pattern);
+    }
+}
+
+
+// ==========================================
+// === Retrieving AST Nodes From Patterns ===
+// ==========================================
+
+/// An AST node being inside a Match node
+#[allow(missing_docs)]
+#[derive(Debug)]
+pub struct AstInPattern {
+    pub ast    : Shifted<Ast>,
+    pub crumbs : Vec<PatternMatchCrumb>,
+}
+
+/// Helper function that returns all AST nodes being on leaves of MacroPatternMatch.
+pub fn all_ast_nodes_in_pattern<'a>
+(pattern:&'a MacroPatternMatch<Shifted<Ast>>) -> impl Iterator<Item=AstInPattern> + 'a {
+    use ast::MacroPatternMatchRaw::*;
+
+    PatternDfs::new(pattern).filter_map(|pattern| {
+        let opt_ast_and_crumb = match pattern.pattern.deref() {
+            Build(pat)   => Some((&pat.elem,PatternMatchCrumb::Build  )),
+            Err(pat)     => Some((&pat.elem,PatternMatchCrumb::Err    )),
+            Tok(pat)     => Some((&pat.elem,PatternMatchCrumb::Tok    )),
+            Blank(pat)   => Some((&pat.elem,PatternMatchCrumb::Blank  )),
+            Var(pat)     => Some((&pat.elem,PatternMatchCrumb::Var    )),
+            Cons(pat)    => Some((&pat.elem,PatternMatchCrumb::Cons   )),
+            Opr(pat)     => Some((&pat.elem,PatternMatchCrumb::Opr    )),
+            Mod(pat)     => Some((&pat.elem,PatternMatchCrumb::Mod    )),
+            Num(pat)     => Some((&pat.elem,PatternMatchCrumb::Num    )),
+            Text(pat)    => Some((&pat.elem,PatternMatchCrumb::Text   )),
+            Block(pat)   => Some((&pat.elem,PatternMatchCrumb::Block  )),
+            Macro(pat)   => Some((&pat.elem,PatternMatchCrumb::Macro  )),
+            Invalid(pat) => Some((&pat.elem,PatternMatchCrumb::Invalid)),
+            _            => None,
+        };
+        opt_ast_and_crumb.map(|(ast,crumb)| {
+            AstInPattern {
+                ast    : ast.clone(),
+                crumbs : pattern.crumbs.into_iter().chain(std::iter::once(crumb)).collect()
+            }
+        })
+    })
+}

--- a/src/rust/ide/span-tree/src/iter.rs
+++ b/src/rust/ide/span-tree/src/iter.rs
@@ -126,24 +126,24 @@ mod tests {
         //                   /|       / | \
         // gg-children:     ()()     ()() ()
 
-        let removable = false;
+        let is_removable = false;
         let tree = TreeBuilder::new(14)
             .add_child(0,10,Chained,vec![LeftOperand])
-                .add_leaf (0,3,Target{removable},vec![LeftOperand])
+                .add_leaf (0,3,Target{is_removable},vec![LeftOperand])
                 .add_leaf (4,1,Operation,vec![Operator])
-                .add_child(6,3,Argument{removable},vec![RightOperand])
+                .add_child(6,3,Argument{is_removable},vec![RightOperand])
                     .add_leaf(0,1,Operation,vec![Func])
-                    .add_leaf(2,1,Target{removable},vec![Arg])
+                    .add_leaf(2,1,Target{is_removable},vec![Arg])
                     .done()
                 .done()
             .add_leaf (11,1,Operation,vec![Operator])
             .add_child(13,1,Chained  ,vec![RightOperand])
-                .add_leaf (0,3,Target{removable},vec![LeftOperand])
+                .add_leaf (0,3,Target{is_removable},vec![LeftOperand])
                 .add_leaf (4,1,Operation,vec![Operator])
                 .add_child(6,5,Chained,vec![RightOperand])
-                    .add_leaf(0,1,Target{removable},vec![LeftOperand])
+                    .add_leaf(0,1,Target{is_removable},vec![LeftOperand])
                     .add_leaf(2,1,Operation,vec![Operator])
-                    .add_leaf(4,1,Argument{removable},vec![RightOperand])
+                    .add_leaf(4,1,Argument{is_removable},vec![RightOperand])
                     .done()
                 .done()
             .build();

--- a/src/rust/ide/span-tree/src/node.rs
+++ b/src/rust/ide/span-tree/src/node.rs
@@ -27,12 +27,12 @@ pub enum Kind {
     /// A node being a target (or "self") parameter of parent Infix, Section or Prefix.
     Target {
         /// Indicates if this node can be erased from SpanTree.
-        removable:bool
+        is_removable:bool
     },
     /// A node being a normal (not target) parameter of parent Infix, Section or Prefix.
     Argument {
         /// Indicates if this node can be erased from SpanTree.
-        removable:bool
+        is_removable:bool
     },
     /// A node being a placeholder for inserting new child to Prefix or Operator chain. It should
     /// have assigned span of length 0 and should not have any child.
@@ -226,14 +226,14 @@ mod test {
     fn node_lookup() {
         use ast::crumbs::InfixCrumb::*;
 
-        let removable = false;
+        let is_removable = false;
         let tree      = TreeBuilder::new(7)
-            .add_leaf (0,1,Target{removable},vec![LeftOperand])
+            .add_leaf (0,1,Target{is_removable},vec![LeftOperand])
             .add_leaf (1,1,Operation,vec![Operator])
-            .add_child(2,5,Argument{removable},vec![RightOperand])
-                .add_leaf(0,2,Target{removable},vec![LeftOperand])
+            .add_child(2,5,Argument{is_removable},vec![RightOperand])
+                .add_leaf(0,2,Target{is_removable},vec![LeftOperand])
                 .add_leaf(3,1,Operation,vec![Operator])
-                .add_leaf(4,1,Argument{removable},vec![RightOperand])
+                .add_leaf(4,1,Argument{is_removable},vec![RightOperand])
                 .done()
             .build();
 
@@ -285,14 +285,14 @@ mod test {
         use ast::crumbs::InfixCrumb::*;
         use ast::crumbs::PrefixCrumb::*;
 
-        let removable = false;
+        let is_removable = false;
         let tree      = TreeBuilder::new(7)
-            .add_leaf (0,1,Target{removable},vec![LeftOperand])
+            .add_leaf (0,1,Target{is_removable},vec![LeftOperand])
             .add_empty_child(1,InsertType::AfterTarget)
             .add_leaf (1,1,Operation,vec![Operator])
-            .add_child(2,5,Argument{removable},vec![RightOperand])
+            .add_child(2,5,Argument{is_removable},vec![RightOperand])
                 .add_leaf(0,3,Operation,vec![Func])
-                .add_leaf(3,1,Target{removable},vec![Arg])
+                .add_leaf(3,1,Target{is_removable},vec![Arg])
             .done()
             .build();
 


### PR DESCRIPTION
### Pull Request Description
Before during SpanTree generation we treated macros as a leaves. Now we properly look into them, get all the AST nodes in their patterns and generate children of these SpanTree nodes from them.

### Important Notes
- Segments' heads are not a SpanTree node.
- There is no possiblity to add or remove children of SpanTree node bound to macro.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

