### PR TITLE
Zero-copy JSON-RPC methods

### DIFF
--- a/src/rust/ide/enso-protocol/src/language_server/connection.rs
+++ b/src/rust/ide/enso-protocol/src/language_server/connection.rs
@@ -48,7 +48,7 @@ impl Connection {
     pub async fn new(client:impl API + 'static) -> FallibleResult<Self> {
         let client_id     = Uuid::new_v4();
         let client        = Box::new(client);
-        let init_response = client.init_protocol_connection(client_id).await;
+        let init_response = client.init_protocol_connection(&client_id).await;
         let init_response = init_response.map_err(|e| FailedToInitializeProtocol(e.into()))?;
         let content_roots = init_response.content_roots;
         if content_roots.is_empty() {

--- a/src/rust/ide/enso-protocol/src/language_server/tests.rs
+++ b/src/rust/ide/enso-protocol/src/language_server/tests.rs
@@ -128,19 +128,19 @@ fn test_file_requests() {
     let unit_json = json!(null);
 
     test_request(
-        |client| client.copy_file(main.clone(), target.clone()),
+        |client| client.copy_file(&main, &target),
         "file/copy",
         from_main_to_target.clone(),
         unit_json.clone(),
         ());
     test_request(
-        |client| client.delete_file(main.clone()),
+        |client| client.delete_file(&main),
         "file/delete",
         path_main.clone(),
         unit_json.clone(),
         ());
     test_request(
-        |client| client.file_exists(main.clone()),
+        |client| client.file_exists(&main),
         "file/exists",
         path_main.clone(),
         file_exists_json,
@@ -179,13 +179,13 @@ fn test_file_requests() {
         ]
     };
     test_request(
-        |client| client.file_list(main.clone()),
+        |client| client.file_list(&main),
         "file/list",
         path_main.clone(),
         list_response_json,
         list_response_value);
     test_request(
-        |client| client.move_file(main.clone(), target.clone()),
+        |client| client.move_file(&main, &target),
         "file/move",
         from_main_to_target.clone(),
         unit_json.clone(),
@@ -194,7 +194,7 @@ fn test_file_requests() {
     let read_response_json = json!({"contents":"Hello world!"});
     let read_response      = response::Read { contents: "Hello world!".into() };
     test_request(
-        |client| client.read_file(main.clone()),
+        |client| client.read_file(&main),
         "file/read",
         path_main.clone(),
         read_response_json,
@@ -235,7 +235,7 @@ fn test_file_requests() {
         "byteSize" : 125125
     }});
     test_request(
-        |client| client.file_info(main.clone()),
+        |client| client.file_info(&main),
         "file/info",
         path_main.clone(),
         sample_attributes_json,
@@ -244,13 +244,13 @@ fn test_file_requests() {
             "object" : file_system_object_json
         });
     test_request(
-        |client| client.create_file(file_system_object),
+        |client| client.create_file(&file_system_object),
         "file/create",
         create_file_json.clone(),
         unit_json.clone(),
         ());
     test_request(
-        |client| client.write_file(main.clone(), "Hello world!".into()),
+        |client| client.write_file(&main, &"Hello world!".to_string()),
         "file/write",
         json!({
             "path" : {
@@ -269,7 +269,7 @@ fn test_protocol_connection() {
         content_roots: vec![uuid::Uuid::default()]
     };
     test_request(
-        |client| client.init_protocol_connection(uuid::Uuid::default()),
+        |client| client.init_protocol_connection(&uuid::Uuid::default()),
         "session/initProtocolConnection",
         json!({
             "clientId" : "00000000-0000-0000-0000-000000000000"
@@ -291,7 +291,7 @@ fn test_acquire_capability() {
     let receives_tree_updates = ReceivesTreeUpdates { path };
     let options               = RegisterOptions::ReceivesTreeUpdates(receives_tree_updates);
     test_request(
-        |client| client.acquire_capability("receivesTreeUpdates".into(), options),
+        |client| client.acquire_capability(&"receivesTreeUpdates".to_string(), &options),
         "capability/acquire",
         json!({
             "method"          : "receivesTreeUpdates",
@@ -345,7 +345,7 @@ fn test_execution_context() {
         create_execution_context_response
     );
     test_request(
-        |client| client.destroy_execution_context(context_id),
+        |client| client.destroy_execution_context(&context_id),
         "executionContext/destroy",
         json!({"contextId":"00000000-0000-0000-0000-000000000000"}),
         unit_json.clone(),
@@ -355,7 +355,7 @@ fn test_execution_context() {
     let local_call    = LocalCall {expression_id};
     let stack_item    = StackItem::LocalCall(local_call);
     test_request(
-        |client| client.push_to_execution_context(context_id,stack_item),
+        |client| client.push_to_execution_context(&context_id,&stack_item),
         "executionContext/push",
         json!({
             "contextId" : "00000000-0000-0000-0000-000000000000",
@@ -368,7 +368,7 @@ fn test_execution_context() {
         ()
     );
     test_request(
-        |client| client.pop_from_execution_context(context_id),
+        |client| client.pop_from_execution_context(&context_id),
         "executionContext/pop",
         json!({"contextId":"00000000-0000-0000-0000-000000000000"}),
         unit_json.clone(),
@@ -382,7 +382,7 @@ fn test_execution_context() {
     {execution_context_id:context_id,expression,visualisation_module};
     test_request(
         |client|
-            client.attach_visualisation(visualisation_id,expression_id,visualisation_config),
+            client.attach_visualisation(&visualisation_id,&expression_id,&visualisation_config),
         "executionContext/attachVisualisation",
         json!({
             "visualisationId"     : "00000000-0000-0000-0000-000000000000",
@@ -397,7 +397,7 @@ fn test_execution_context() {
         ()
     );
     test_request(
-        |client| client.detach_visualisation(context_id,visualisation_id,expression_id),
+        |client| client.detach_visualisation(&context_id,&visualisation_id,&expression_id),
         "executionContext/detachVisualisation",
         json!({
             "contextId"       : "00000000-0000-0000-0000-000000000000",
@@ -412,7 +412,7 @@ fn test_execution_context() {
     let visualisation_config = VisualisationConfiguration
     {execution_context_id:context_id,expression,visualisation_module};
     test_request(
-        |client| client.modify_visualisation(visualisation_id,visualisation_config),
+        |client| client.modify_visualisation(&visualisation_id,&visualisation_config),
         "executionContext/modifyVisualisation",
         json!({
             "visualisationId"     : "00000000-0000-0000-0000-000000000000",
@@ -435,7 +435,7 @@ fn test_execution_context() {
     let open_text_file_response = response::OpenTextFile
     {content,current_version:current_version.clone(),write_capability};
     test_request(
-        |client| client.open_text_file(main.clone()),
+        |client| client.open_text_file(&main),
         "text/openFile",
         json!({
             "path" : {
@@ -469,7 +469,7 @@ fn test_execution_context() {
     let path        = main.clone();
     let edit        = FileEdit {path,edits,old_version,new_version:new_version.clone()};
     test_request(
-        |client| client.apply_text_file_edit(edit),
+        |client| client.apply_text_file_edit(&edit),
         "text/applyEdit",
         json!({
             "edit" : {
@@ -500,7 +500,7 @@ fn test_execution_context() {
         ()
     );
     test_request(
-        |client| client.save_text_file(main.clone(),current_version),
+        |client| client.save_text_file(&main,&current_version),
         "text/save",
         json!({
             "path" : {
@@ -513,7 +513,7 @@ fn test_execution_context() {
         ()
     );
     test_request(
-        |client| client.close_text_file(main),
+        |client| client.close_text_file(&main),
         "text/closeFile",
         json!({
             "path" : {

--- a/src/rust/ide/enso-protocol/src/project_manager.rs
+++ b/src/rust/ide/enso-protocol/src/project_manager.rs
@@ -183,25 +183,25 @@ mod mock_client_tests {
         mock_client.set_close_project_result(expected_uuid.clone(),error("Project isn't open."));
         mock_client.set_delete_project_result(expected_uuid.clone(),error("Project doesn't exist."));
 
-        let delete_result = mock_client.delete_project(expected_uuid.clone());
+        let delete_result = mock_client.delete_project(&expected_uuid);
         result(delete_result).expect_err("Project shouldn't exist.");
 
-        let creation_response = mock_client.create_project("HelloWorld".into());
+        let creation_response = mock_client.create_project(&"HelloWorld".to_string());
         let uuid = result(creation_response).expect("Couldn't create project").project_id;
         assert_eq!(uuid, expected_uuid);
 
-        let close_result = result(mock_client.close_project(uuid.clone()));
+        let close_result = result(mock_client.close_project(&uuid));
         close_result.expect_err("Project shouldn't be open.");
 
-        let ip_with_socket = result(mock_client.open_project(uuid.clone()));
+        let ip_with_socket = result(mock_client.open_project(&uuid));
         let ip_with_socket = ip_with_socket.expect("Couldn't open project");
         assert_eq!(ip_with_socket, expected_ip_with_socket);
 
         mock_client.set_close_project_result(expected_uuid.clone(), Ok(()));
-        result(mock_client.close_project(uuid)).expect("Couldn't close project.");
+        result(mock_client.close_project(&uuid)).expect("Couldn't close project.");
 
         mock_client.set_delete_project_result(expected_uuid.clone(), Ok(()));
-        result(mock_client.delete_project(uuid)).expect("Couldn't delete project.");
+        result(mock_client.delete_project(&uuid)).expect("Couldn't delete project.");
     }
 
     #[test]
@@ -234,9 +234,9 @@ mod mock_client_tests {
 
         let list_recent_error = "Couldn't get recent projects.";
         let list_sample_error = "Couldn't get sample projects.";
-        let recent_projects = result(mock_client.list_recent_projects(2)).expect(list_recent_error);
+        let recent_projects = result(mock_client.list_recent_projects(&2)).expect(list_recent_error);
         assert_eq!(recent_projects, expected_recent_projects);
-        let sample_projects = result(mock_client.list_samples(2)).expect(list_sample_error);
+        let sample_projects = result(mock_client.list_samples(&2)).expect(list_sample_error);
         assert_eq!(sample_projects, expected_sample_projects);
     }
 }
@@ -357,42 +357,42 @@ mod remote_client_tests {
         });
 
         test_request(
-            |client| client.list_recent_projects(number_of_projects),
+            |client| client.list_recent_projects(&number_of_projects),
             "project/listRecent",
             &number_of_projects_json,
             &project_list_json,
             &project_list
         );
         test_request(
-            |client| client.list_samples(number_of_projects),
+            |client| client.list_samples(&number_of_projects),
             "project/listSample",
             &num_projects_json,
             &project_list_json,
             &project_list
         );
         test_request(
-            |client| client.open_project(project_id.clone()),
+            |client| client.open_project(&project_id),
             "project/open",
             &project_id_json,
             &ip_with_address_json,
             &ip_with_address
         );
         test_request(
-            |client| client.close_project(project_id.clone()),
+            |client| client.close_project(&project_id),
             "project/close",
             &project_id_json,
             &unit_json,
             &()
         );
         test_request(
-            |client| client.delete_project(project_id.clone()),
+            |client| client.delete_project(&project_id),
             "project/delete",
             &project_id_json,
             &unit_json,
             &()
         );
         test_request(
-            |client| client.create_project(project_name.clone()),
+            |client| client.create_project(&project_name),
             "project/create",
             &project_name_json,
             &project_id_json,

--- a/src/rust/ide/json-rpc/src/handler.rs
+++ b/src/rust/ide/json-rpc/src/handler.rs
@@ -254,7 +254,7 @@ impl<Notification> Handler<Notification> {
     pub fn open_request_with_json<Returned:DeserializeOwned>
     (&self, method_name:&str, input:&serde_json::Value) -> impl Future<Output = Result<Returned>> {
         let id      = self.generate_new_id();
-        let message = crate::messages::Message::new_request(id,method_name,input); //api::into_request_message(input,id);
+        let message = crate::messages::Message::new_request(id,method_name,input);
         let serialized_message = serde_json::to_string(&message).unwrap();
         self.open_request_with_message(id,&serialized_message)
     }
@@ -263,7 +263,7 @@ impl<Notification> Handler<Notification> {
     ///
     /// Helper common \code for `open_request` and `open_request_with_json`. See
     /// `open_request_with_json` docstring for more information.
-    pub fn open_request_with_message<'a, Returned:DeserializeOwned>
+    pub fn open_request_with_message<Returned:DeserializeOwned>
     (&self, id:Id, message_json:&str) -> impl Future<Output = Result<Returned>> {
         let (sender, receiver) = oneshot::channel::<ReplyMessage>();
         let ret                = receiver.map(|result_or_cancel| {

--- a/src/rust/ide/json-rpc/src/handler.rs
+++ b/src/rust/ide/json-rpc/src/handler.rs
@@ -234,18 +234,45 @@ impl<Notification> Handler<Notification> {
     /// reply message. It is automatically decoded into the expected type.
     pub fn open_request<In:api::RemoteMethodCall>
     (&self, input:In) -> impl Future<Output = Result<In::Returned>> {
+        let id      = self.generate_new_id();
+        let message = api::into_request_message(input,id);
+        let serialized_message = serde_json::to_string(&message).unwrap();
+        self.open_request_with_message(id,&serialized_message)
+    }
+
+    /// Sends a request to the peer and returns a `Future` that shall yield a reply message.
+    ///
+    /// This method exists to workaround a Rust compiler issue preventing using any kind of
+    /// non-static generic types together with `impl trait` return syntax when the returned type may
+    /// be required to be static. See: https://github.com/rust-lang/rust/issues/42940
+    ///
+    /// We avoid this by removing `api::RemoteMethodCall`-trait-bound type parameter (which would
+    /// include a lifetime) and by passing JSON and method named obtained from it separately.
+    /// This is suboptimal but still less evil than cloning all input arguments like before.
+    ///
+    /// FIXME: when possible unify with `open_request`
+    pub fn open_request_with_json<Returned:DeserializeOwned>
+    (&self, method_name:&str, input:&serde_json::Value) -> impl Future<Output = Result<Returned>> {
+        let id      = self.generate_new_id();
+        let message = crate::messages::Message::new_request(id,method_name,input); //api::into_request_message(input,id);
+        let serialized_message = serde_json::to_string(&message).unwrap();
+        self.open_request_with_message(id,&serialized_message)
+    }
+
+    /// Sends a request to the peer and returns a `Future` that shall yield a reply message.
+    ///
+    /// Helper common \code for `open_request` and `open_request_with_json`. See
+    /// `open_request_with_json` docstring for more information.
+    pub fn open_request_with_message<'a, Returned:DeserializeOwned>
+    (&self, id:Id, message_json:&str) -> impl Future<Output = Result<Returned>> {
         let (sender, receiver) = oneshot::channel::<ReplyMessage>();
         let ret                = receiver.map(|result_or_cancel| {
             let result = result_or_cancel?;
             decode_result(result)
         });
 
-        let id      = self.generate_new_id();
-        let message = api::into_request_message(input,id);
-        self.insert_ongoing_request(message.payload.id, sender);
-
-        let serialized_message = serde_json::to_string(&message).unwrap();
-        if self.send_text_message(&serialized_message).is_err() {
+        self.insert_ongoing_request(id,sender);
+        if self.send_text_message(message_json).is_err() {
             // If message cannot be send, future ret must be cancelled.
             self.remove_ongoing_request(id);
         }

--- a/src/rust/ide/json-rpc/src/macros.rs
+++ b/src/rust/ide/json-rpc/src/macros.rs
@@ -1,7 +1,6 @@
 //! Helper macros to generate RemoteClient and MockClient.
 
-// FIXME[dg]: https://github.com/luna/ide/issues/401 We want to make the generated methods to
-// take references instead of ownership.
+// TODO[dg]: Make it possible to create an API which accepts pass both references and ownership.
 /// This macro reads a `trait API` item and generates asynchronous methods for RPCs. Each method
 /// should be signed with `MethodInput`, `rpc_name`, `result` and `set_result` attributes. e.g.:
 /// ```rust,compile_fail
@@ -41,7 +40,7 @@ macro_rules! make_rpc_methods {
         pub trait API {
             $(
                 $(#[doc = $doc])+
-                fn $method(&self $(,$param_name:$param_ty)*)
+                fn $method<'a>(&'a self $(,$param_name:&'a $param_ty)*)
                 -> std::pin::Pin<Box<dyn Future<Output=Result<$result>>>>;
             )*
         }
@@ -82,22 +81,29 @@ macro_rules! make_rpc_methods {
         }
 
         impl API for Client {
-            $(fn $method(&self, $($param_name:$param_ty),*)
+            $(fn $method<'a>(&'a self, $($param_name:&'a $param_ty),*)
             -> std::pin::Pin<Box<dyn Future<Output=Result<$result>>>> {
-                let input = $method_input { $($param_name:$param_name),* };
-                Box::pin(self.handler.borrow().open_request(input))
+                use json_rpc::api::RemoteMethodCall;
+                let phantom    = std::marker::PhantomData;
+                let input      = $method_input { phantom, $($param_name:&$param_name),* };
+                let input_json = serde_json::to_value(input).unwrap();
+                let name       = $method_input::NAME;
+                let result_fut = self.handler.borrow().open_request_with_json(name,&input_json);
+                Box::pin(result_fut)
             })*
         }
 
         $(
             /// Structure transporting method arguments.
-            #[derive(Serialize,Deserialize,Debug,PartialEq)]
+            #[derive(Serialize,Debug,PartialEq)]
             #[serde(rename_all = "camelCase")]
-            struct $method_input {
-                $($param_name : $param_ty),*
+            struct $method_input<'a> {
+                #[serde(skip)]
+                phantom : std::marker::PhantomData<&'a u8>,
+                $($param_name : &'a $param_ty),*
             }
 
-            impl json_rpc::RemoteMethodCall for $method_input {
+            impl json_rpc::RemoteMethodCall for $method_input<'_> {
                 const NAME:&'static str = $rpc_name;
                 type Returned = $result;
             }
@@ -117,10 +123,10 @@ macro_rules! make_rpc_methods {
         }
 
         impl API for MockClient {
-            $(fn $method(&self $(,$param_name:$param_ty)*)
+            $(fn $method<'a>(&'a self $(,$param_name:&'a $param_ty)*)
             -> std::pin::Pin<Box<dyn Future<Output=Result<$result>>>> {
                 let mut results = self.$method_result.borrow_mut();
-                let params      = ($($param_name),*);
+                let params      = ($($param_name.clone()),*);
                 let result      = results.get_mut(&params).and_then(|res| res.pop());
                 let err         = format!("Unrecognized call {} with params {:?}",$rpc_name,params);
                 Box::pin(futures::future::ready(result.expect(err.as_str())))

--- a/src/rust/ide/json-rpc/src/macros.rs
+++ b/src/rust/ide/json-rpc/src/macros.rs
@@ -100,7 +100,7 @@ macro_rules! make_rpc_methods {
             #[serde(rename_all = "camelCase")]
             struct $method_input<'a> {
                 #[serde(skip)]
-                phantom : std::marker::PhantomData<&'a u8>,
+                phantom : std::marker::PhantomData<&'a()>,
                 $($param_name : &'a $param_ty),*
             }
 

--- a/src/rust/ide/json-rpc/src/macros.rs
+++ b/src/rust/ide/json-rpc/src/macros.rs
@@ -8,7 +8,7 @@
 ///     trait API {
 ///         #[MethodInput=CallMePleaseInput,camelCase=callMePlease,result=call_me_please_result,
 ///         set_result=set_call_me_please_result]
-///         fn call_me_please(&self, my_number_is:String) -> ();
+///         fn call_me_please<'a>(&'a self, my_number_is:&'a String) -> ();
 ///     }
 /// }
 /// ```

--- a/src/rust/ide/json-rpc/src/macros.rs
+++ b/src/rust/ide/json-rpc/src/macros.rs
@@ -37,6 +37,7 @@ macro_rules! make_rpc_methods {
         // ===========
 
         $(#[doc = $impl_doc])+
+        #[allow(clippy::ptr_arg)]
         pub trait API {
             $(
                 $(#[doc = $doc])+

--- a/src/rust/ide/src/controller/module.rs
+++ b/src/rust/ide/src/controller/module.rs
@@ -127,7 +127,7 @@ impl Handle {
     pub async fn load_file(&self) -> FallibleResult<()> {
         self.logger.info(|| "Loading module file");
         let path    = self.path.file_path().clone();
-        let content = self.language_server.client.read_file(path).await?.contents;
+        let content = self.language_server.client.read_file(&path).await?.contents;
         self.logger.info(|| "Parsing code");
         // TODO[ao] We should not fail here when metadata are malformed, but discard them and set
         //  default instead.
@@ -143,7 +143,7 @@ impl Handle {
         let path    = self.path.file_path().clone();
         let ls      = self.language_server.clone();
         let content = self.model.source_as_string();
-        async move { Ok(ls.client.write_file(path,content?).await?) }
+        async move { Ok(ls.client.write_file(&path,&content?).await?) }
     }
 
     /// Updates AST after code change.

--- a/src/rust/ide/src/controller/text.rs
+++ b/src/rust/ide/src/controller/text.rs
@@ -69,7 +69,7 @@ impl Handle {
         use FileHandle::*;
         match &self.file {
             PlainText {path,language_server} => {
-                let response = language_server.read_file(path.deref().clone()).await;
+                let response = language_server.read_file(&path).await;
                 response.map(|response| response.contents)
             },
             Module{controller} => Ok(controller.code())
@@ -82,7 +82,7 @@ impl Handle {
         async move {
             match file_handle {
                 FileHandle::PlainText {path,language_server} => {
-                    language_server.write_file(path.deref().clone(),content).await?
+                    language_server.write_file(&path,&content).await?
                 },
                 FileHandle::Module {controller} => {
                     controller.check_code_sync(content)?;

--- a/src/rust/ide/src/lib.rs
+++ b/src/rust/ide/src/lib.rs
@@ -153,13 +153,13 @@ pub async fn open_project
 /// Open most recent project or create a new project if none exists.
 pub async fn open_most_recent_project_or_create_new
 (project_manager:&impl project_manager::API) -> FallibleResult<controller::Project> {
-    let mut response = project_manager.list_recent_projects(1).await?;
+    let mut response = project_manager.list_recent_projects(&1).await?;
     let project_id = if let Some(project) = response.projects.pop() {
         project.id
     } else {
-        project_manager.create_project(DEFAULT_PROJECT_NAME.into()).await?.project_id
+        project_manager.create_project(&DEFAULT_PROJECT_NAME.to_string()).await?.project_id
     };
-    let address = project_manager.open_project(project_id).await?.language_server_rpc_address;
+    let address = project_manager.open_project(&project_id).await?.language_server_rpc_address;
     open_project(address).await
 }
 

--- a/src/rust/ide/src/lib.rs
+++ b/src/rust/ide/src/lib.rs
@@ -153,7 +153,8 @@ pub async fn open_project
 /// Open most recent project or create a new project if none exists.
 pub async fn open_most_recent_project_or_create_new
 (project_manager:&impl project_manager::API) -> FallibleResult<controller::Project> {
-    let mut response = project_manager.list_recent_projects(&1).await?;
+    let projects_to_list = 1;
+    let mut response     = project_manager.list_recent_projects(&projects_to_list).await?;
     let project_id = if let Some(project) = response.projects.pop() {
         project.id
     } else {

--- a/src/rust/ide/src/model/synchronized/execution_context.rs
+++ b/src/rust/ide/src/model/synchronized/execution_context.rs
@@ -56,7 +56,7 @@ impl ExecutionContext {
         let call = language_server::ExplicitCall {method_pointer,this_argument_expression,
             positional_arguments_expressions};
         let frame  = language_server::StackItem::ExplicitCall(call);
-        let result = self.language_server.push_to_execution_context(self.id,frame);
+        let result = self.language_server.push_to_execution_context(&self.id,&frame);
         result.map(|res| res.map_err(|err| err.into()))
     }
 
@@ -66,14 +66,14 @@ impl ExecutionContext {
         let call          = language_server::LocalCall{expression_id};
         let frame         = language_server::StackItem::LocalCall(call);
         self.model.push(stack_item);
-        self.language_server.push_to_execution_context(self.id,frame)
+        self.language_server.push_to_execution_context(&self.id,&frame)
     }
 
     /// Pop the last stack item from this context. It returns error when only root call
     /// remains.
     pub async fn pop(&self) -> FallibleResult<()> {
         self.model.pop()?;
-        self.language_server.pop_from_execution_context(self.id).await?;
+        self.language_server.pop_from_execution_context(&self.id).await?;
         Ok(())
     }
 
@@ -98,7 +98,7 @@ impl Drop for ExecutionContext {
         let ls     = self.language_server.clone_ref();
         let logger = self.logger.clone_ref();
         executor::global::spawn(async move {
-            let result = ls.client.destroy_execution_context(id).await;
+            let result = ls.client.destroy_execution_context(&id).await;
             if result.is_err() {
                 error!(logger,"Error when destroying Execution Context: {result:?}.");
             }

--- a/src/rust/ide/tests/language_server.rs
+++ b/src/rust/ide/tests/language_server.rs
@@ -67,23 +67,23 @@ async fn file_operations() {
     executor::global::spawn(client.runner());
 
     let client_id = uuid::Uuid::new_v4();
-    let session   = client.init_protocol_connection(client_id).await;
+    let session   = client.init_protocol_connection(&client_id).await;
     let session   = session.expect("Couldn't initialize session.");
     let root_id   = session.content_roots[0];
 
     let file      = Path{root_id,segments:vec!["src".into(),"Main.enso".into()]};
     let contents  = MAIN_CODE.to_string();
-    let result    = client.write_file(file.clone(),contents).await;
+    let result    = client.write_file(&file,&contents).await;
     result.expect("Couldn't write main code file.");
 
     let visualisation_file = Path{root_id,segments:vec!["src".into(),"Visualisation.enso".into()]};
     let contents           = VISUALISATION_CODE.to_string();
-    let response           = client.write_file(visualisation_file,contents).await;
+    let response           = client.write_file(&visualisation_file,&contents).await;
     response.expect("Couldn't write visualisation file.");
 
     let package_file = Path{root_id,segments:vec!["package.yaml".into()]};
     let contents     = PACKAGE_YAML.to_string();
-    let response     = client.write_file(package_file,contents).await;
+    let response     = client.write_file(&package_file,&contents).await;
     response.expect("Couldn't write yaml file.");
 
     let execution_context    = client.create_execution_context().await;
@@ -101,10 +101,10 @@ async fn file_operations() {
     let explicit_call                    = ExplicitCall
         {method_pointer,positional_arguments_expressions,this_argument_expression};
     let stack_item = StackItem::ExplicitCall(explicit_call);
-    let response   = client.push_to_execution_context(execution_context_id,stack_item).await;
+    let response   = client.push_to_execution_context(&execution_context_id,&stack_item).await;
     response.expect("Couldn't push execution context.");
 
-    let response = client.pop_from_execution_context(execution_context_id).await;
+    let response = client.pop_from_execution_context(&execution_context_id).await;
     response.expect("Couldn't pop execution context.");
 
     let visualisation_id     = uuid::Uuid::new_v4();
@@ -115,68 +115,68 @@ async fn file_operations() {
     let visualisation_config = VisualisationConfiguration
     {execution_context_id,expression,visualisation_module};
     let response = client.attach_visualisation
-        (visualisation_id,expression_id.clone(),visualisation_config);
+        (&visualisation_id,&expression_id,&visualisation_config);
     response.await.expect("Couldn't attach visualisation.");
 
     let expression           = "x -> here.incAndEncode".to_string();
     let visualisation_module = "Test.Visualisation".to_string();
     let visualisation_config = VisualisationConfiguration
     {execution_context_id,expression,visualisation_module};
-    let response = client.modify_visualisation(visualisation_id,visualisation_config).await;
+    let response = client.modify_visualisation(&visualisation_id,&visualisation_config).await;
     response.expect("Couldn't modify visualisation.");
 
     let response = client.detach_visualisation
-        (execution_context_id,visualisation_id,expression_id).await;
+        (&execution_context_id,&visualisation_id,&expression_id).await;
     response.expect("Couldn't detach visualisation.");
 
-    let response = client.destroy_execution_context(execution_context_id).await;
+    let response = client.destroy_execution_context(&execution_context_id).await;
     response.expect("Couldn't destroy execution context.");
 
     let path      = Path{root_id, segments:vec!["foo".into()]};
     let name      = "text.txt".into();
     let object    = FileSystemObject::File {name,path};
-    client.create_file(object.clone()).await.expect("Couldn't create file.");
+    client.create_file(&object).await.expect("Couldn't create file.");
 
     let file_path = Path{root_id, segments:vec!["foo".into(),"text.txt".into()]};
     let contents  = "Hello world!".to_string();
-    let result    = client.write_file(file_path.clone(),contents.clone()).await;
+    let result    = client.write_file(&file_path,&contents).await;
     result.expect("Couldn't write file.");
 
-    let response = client.file_info(file_path.clone()).await.expect("Couldn't get status.");
+    let response = client.file_info(&file_path).await.expect("Couldn't get status.");
     assert_eq!(response.attributes.byte_size,12);
     assert_eq!(response.attributes.kind,object);
 
-    let response = client.file_list(Path{root_id,segments:vec!["foo".into()]}).await;
+    let response = client.file_list(&Path{root_id,segments:vec!["foo".into()]}).await;
     let response = response.expect("Couldn't get file list");
     assert!(response.paths.iter().any(|file_system_object| object == *file_system_object));
 
-    let read = client.read_file(file_path.clone()).await.expect("Couldn't read contents.");
+    let read = client.read_file(&file_path).await.expect("Couldn't read contents.");
     assert_eq!(contents,read.contents);
 
     let new_path = Path{root_id,segments:vec!["foo".into(),"new_text.txt".into()]};
-    client.copy_file(file_path,new_path.clone()).await.expect("Couldn't copy file");
-    let read = client.read_file(new_path.clone()).await.expect("Couldn't read contents.");
+    client.copy_file(&file_path,&new_path).await.expect("Couldn't copy file");
+    let read = client.read_file(&new_path).await.expect("Couldn't read contents.");
     assert_eq!(contents,read.contents);
 
     let move_path = Path{root_id,segments:vec!["foo".into(),"moved_text.txt".into()]};
-    let file      = client.file_exists(move_path.clone()).await;
+    let file      = client.file_exists(&move_path).await;
     let file      = file.expect("Couldn't check if file exists.");
     if file.exists {
-        client.delete_file(move_path.clone()).await.expect("Couldn't delete file");
-        let file = client.file_exists(move_path.clone()).await;
+        client.delete_file(&move_path).await.expect("Couldn't delete file");
+        let file = client.file_exists(&move_path).await;
         let file = file.expect("Couldn't check if file exists.");
         assert_eq!(file.exists,false);
     }
 
-    client.move_file(new_path,move_path.clone()).await.expect("Couldn't move file");
-    let read = client.read_file(move_path.clone()).await.expect("Couldn't read contents");
+    client.move_file(&new_path,&move_path).await.expect("Couldn't move file");
+    let read = client.read_file(&move_path).await.expect("Couldn't read contents");
     assert_eq!(contents,read.contents);
 
     let receives_tree_updates   = ReceivesTreeUpdates{path:move_path.clone()};
     let register_options        = RegisterOptions::ReceivesTreeUpdates(receives_tree_updates);
     let method                  = "text/canEdit".to_string();
     let capability_registration = CapabilityRegistration {method,register_options};
-    let response = client.open_text_file(move_path.clone()).await;
+    let response = client.open_text_file(&move_path).await;
     let response = response.expect("Couldn't open text file.");
     assert_eq!(response.content, "Hello world!");
     assert_eq!(response.write_capability, Some(capability_registration));
@@ -191,14 +191,14 @@ async fn file_operations() {
     let new_version = Sha3_224::new(b"Hello, world!");
     let path        = move_path.clone();
     let edit        = FileEdit {path,edits,old_version,new_version:new_version.clone()};
-    client.apply_text_file_edit(edit).await.expect("Couldn't apply edit.");
+    client.apply_text_file_edit(&edit).await.expect("Couldn't apply edit.");
 
-    let future = client.save_text_file(move_path.clone(),new_version).await;
+    let future = client.save_text_file(&move_path,&new_version).await;
     future.expect("Couldn't save file.");
 
-    client.close_text_file(move_path.clone()).await.expect("Couldn't close text file.");
+    client.close_text_file(&move_path).await.expect("Couldn't close text file.");
 
-    let read = client.read_file(move_path.clone()).await.expect("Couldn't read contents.");
+    let read = client.read_file(&move_path).await.expect("Couldn't read contents.");
     assert_eq!("Hello, world!".to_string(),read.contents);
 }
 
@@ -216,16 +216,16 @@ async fn file_events() {
     executor::global::spawn(client.runner());
 
     let client_id = uuid::Uuid::default();
-    let session   = client.init_protocol_connection(client_id).await;
+    let session   = client.init_protocol_connection(&client_id).await;
     let session   = session.expect("Couldn't initialize session.");
     let root_id   = session.content_roots[0];
 
     let path      = Path{root_id,segments:vec!["test.txt".into()]};
-    let file      = client.file_exists(path.clone()).await;
+    let file      = client.file_exists(&path).await;
     let file      = file.expect("Couldn't check if file exists.");
     if file.exists {
-        client.delete_file(path.clone()).await.expect("Couldn't delete file");
-        let file = client.file_exists(path.clone()).await;
+        client.delete_file(&path).await.expect("Couldn't delete file");
+        let file = client.file_exists(&path).await;
         let file = file.expect("Couldn't check if file exists.");
         assert_eq!(file.exists,false);
     }
@@ -233,13 +233,13 @@ async fn file_events() {
     let path       = Path{root_id, segments:vec![]};
     let receives_tree_updates = ReceivesTreeUpdates{path};
     let options    = RegisterOptions::ReceivesTreeUpdates(receives_tree_updates);
-    let capability = client.acquire_capability("receivesTreeUpdates".into(),options).await;
+    let capability = client.acquire_capability(&"receivesTreeUpdates".to_string(),&options).await;
     capability.expect("Couldn't acquire receivesTreeUpdates capability.");
 
     let path      = Path{root_id, segments:vec![]};
     let name      = "test.txt".into();
     let object    = FileSystemObject::File {name,path:path.clone()};
-    client.create_file(object).await.expect("Couldn't create file.");
+    client.create_file(&object).await.expect("Couldn't create file.");
 
     let path         = Path{root_id,segments:vec!["test.txt".into()]};
     let kind         = FileEventKind::Added;

--- a/src/rust/ide/tests/project_manager.rs
+++ b/src/rust/ide/tests/project_manager.rs
@@ -23,12 +23,12 @@ mod tests {
         executor::global::spawn(client.runner());
 
         let name     = "TestProject".to_string();
-        let creation = client.create_project(name).await.expect("Couldn't create project.");
+        let creation = client.create_project(&name).await.expect("Couldn't create project.");
         let uuid     = creation.project_id;
-        let _address = client.open_project(uuid.clone()).await.expect("Couldn't open project.");
-        client.close_project(uuid.clone()).await.expect("Couldn't close project.");
-        client.delete_project(uuid).await.expect("Couldn't delete project.");
-        client.list_recent_projects(10).await.expect("Couldn't list recent projects.");
+        let _address = client.open_project(&uuid).await.expect("Couldn't open project.");
+        client.close_project(&uuid).await.expect("Couldn't close project.");
+        client.delete_project(&uuid).await.expect("Couldn't delete project.");
+        client.list_recent_projects(&10).await.expect("Couldn't list recent projects.");
         // FIXME[dg]: project/listSample isn't implemented on the server-side yet.
         //client.list_samples(10).await.expect("Couldn't list samples.");
     }


### PR DESCRIPTION
### Pull Request Description
This PR introduces zero-copy JSON-RPC methods wherever it's possible.

### Important Notes
* Every parameter is translated as references so we don't need to move ownership.
* It's also true for copy types such as atomic types.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

