### PR TITLE
Removed logs that I've accidentally enabled

### DIFF
--- a/src/rust/lib/logger/src/lib.rs
+++ b/src/rust/lib/logger/src/lib.rs
@@ -77,16 +77,16 @@ impl Logger {
 
 #[cfg(target_arch = "wasm32")]
 impl Logger {
-    pub fn trace<M: LogMsg>(&self, msg: M) {
-        console::trace_1(&self.format(msg));
+    pub fn trace<M: LogMsg>(&self, _msg: M) {
+        //console::trace_1(&self.format(msg));
     }
 
     pub fn debug<M: LogMsg>(&self, msg: M) {
         console::debug_1(&self.format(msg));
     }
 
-    pub fn info<M: LogMsg>(&self, msg: M) {
-        console::info_1(&self.format(msg));
+    pub fn info<M: LogMsg>(&self, _msg: M) {
+        //console::info_1(&self.format(msg));
     }
 
     pub fn warning<M: LogMsg>(&self, msg: M) {
@@ -97,12 +97,12 @@ impl Logger {
         console::error_1(&self.format(msg));
     }
 
-    pub fn group_begin<M: LogMsg>(&self, msg: M) {
-        console::group_1(&self.format(msg));
+    pub fn group_begin<M: LogMsg>(&self, _msg: M) {
+        //console::group_1(&self.format(msg));
     }
 
     pub fn group_end(&self) {
-        console::group_end();
+        //console::group_end();
     }
 }
 


### PR DESCRIPTION
### Pull Request Description
In my previous PR I mistakenly merged the version with logs enabled. 
Logs that shouldn't be enabled, until we implement #444 — they slow us down way too much.
This reverts this change.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [ ] The documentation has been updated if necessary.
- [ ] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [ ] All code has been tested where possible.

