### PR TITLE
Refactored utilities for testing Futures and Streams

### DIFF
--- a/src/rust/ide/enso-protocol/src/lib.rs
+++ b/src/rust/ide/enso-protocol/src/lib.rs
@@ -43,6 +43,8 @@ pub mod prelude {
     pub use futures::FutureExt;
     pub use futures::Stream;
     pub use futures::StreamExt;
+
+    #[cfg(test)] pub use utils::test::traits::*;
 }
 
 /// Module gathering all traits which may be used by crate's users.
@@ -57,4 +59,3 @@ pub mod traits {
     pub use crate::language_server::API as TRAIT_LanguageServerAPI;
     pub use crate::project_manager::API as TRAIT_ProjectManagerAPI;
 }
-

--- a/src/rust/ide/enso-protocol/src/project_manager.rs
+++ b/src/rust/ide/enso-protocol/src/project_manager.rs
@@ -149,7 +149,6 @@ mod mock_client_tests {
     use json_rpc::messages::Error;
     use json_rpc::Result;
     use std::future::Future;
-    use utils::test::poll;
     use uuid::Uuid;
 
     fn error<T>(message:&str) -> Result<T> {
@@ -162,7 +161,7 @@ mod mock_client_tests {
 
     fn result<T,F:Future<Output = Result<T>>>(fut:F) -> Result<T> {
         let mut fut = Box::pin(fut);
-        poll(&mut fut).expect("Promise isn't ready")
+        fut.expect_ready()
     }
 
     #[test]
@@ -258,7 +257,6 @@ mod remote_client_tests {
     use serde_json::json;
     use serde_json::Value;
     use std::future::Future;
-    use utils::test::poll;
     use futures::task::LocalSpawnExt;
 
     struct Fixture {
@@ -300,7 +298,7 @@ mod remote_client_tests {
         let response = Message::new_success(request.id, result);
         fixture.transport.mock_peer_json_message(response);
         fixture.executor.run_until_stalled();
-        let output = poll(&mut fut).unwrap().unwrap();
+        let output = fut.expect_ok();
         assert_eq!(output, *expected_output);
     }
 

--- a/src/rust/ide/json-rpc/src/lib.rs
+++ b/src/rust/ide/json-rpc/src/lib.rs
@@ -27,3 +27,5 @@ pub use transport::Transport;
 pub use transport::TransportEvent;
 pub use handler::Event;
 pub use handler::Handler;
+
+#[cfg(test)] pub use utils::test::traits::*;

--- a/src/rust/ide/json-rpc/tests/test.rs
+++ b/src/rust/ide/json-rpc/tests/test.rs
@@ -1,7 +1,8 @@
-use prelude::*;
+use json_rpc::prelude::*;
 
 use futures::FutureExt;
 use futures::Stream;
+use futures::task::LocalSpawnExt;
 use json_rpc::*;
 use json_rpc::api::RemoteMethodCall;
 use json_rpc::api::Result;
@@ -15,9 +16,7 @@ use serde::Deserialize;
 use serde::Serialize;
 use std::future::Future;
 use std::pin::Pin;
-use utils::test::poll;
-use utils::test::poll_stream_output;
-use futures::task::LocalSpawnExt;
+use utils::test::traits::*;
 
 type MockEvent = json_rpc::handler::Event<MockNotification>;
 
@@ -93,29 +92,25 @@ impl Client {
         self.handler.runner()
     }
 
-    pub fn try_get_event(&mut self) -> Option<MockEvent> {
-        poll_stream_output(&mut self.events_stream)
-    }
-
-    pub fn try_get_notification(&mut self) -> Option<MockNotification> {
-        let event = self.try_get_event()?;
-        if let MockEvent::Notification(n) = event {
-            Some(n)
-        } else {
-            None
-        }
+    pub fn expect_no_notification_yet(&mut self) {
+        self.events_stream.expect_pending()
     }
 
     pub fn expect_notification(&mut self) -> MockNotification {
-        self.try_get_notification().expect("expected notification event")
+        let event = self.events_stream.expect_next();
+        if let MockEvent::Notification(notification) = event {
+            notification
+        } else {
+            panic!("Expected a notification, got different kind of event: {:?}",event)
+        }
     }
 
     pub fn expect_handling_error(&mut self) -> HandlingError {
-        let event = self.try_get_event().expect("no events, while expected error event");
+        let event = self.events_stream.expect_next();
         if let json_rpc::handler::Event::Error(err) = event {
             err
         } else {
-            panic!("expected error event, encountered: {:?}", event)
+            panic!("Expected an error event, got different kind of event: {:?}", event)
         }
     }
 }
@@ -157,21 +152,19 @@ fn test_success_call() {
     assert_eq!(req_msg.i, call_input);
     assert_eq!(req_msg.jsonrpc, Version::V2);
 
-    assert!(poll(&mut fut).is_none()); // no reply
+    fut.expect_pending(); // no reply
 
     // let's reply
     let reply = pow_impl(req_msg);
     fixture.transport.mock_peer_json_message(reply);
 
     // before yielding control message should be in buffer and futures should not complete
-    assert!(poll(&mut fut).is_none()); // not ticked
+    fut.expect_pending(); // not ticked
 
     // yield control to executor
     fixture.pool.run_until_stalled();
 
-    let result = poll(&mut fut);
-    let result = result.expect("result should be present");
-    let result = result.expect("result should be a success");
+    let result = fut.expect_ok();
     assert_eq!(result, 8*8);
 }
 
@@ -179,7 +172,7 @@ fn test_success_call() {
 fn test_error_call() {
     let mut fixture = Fixture::new();
     let mut fut     = Box::pin(fixture.client.pow(8));
-    assert!(poll(&mut fut).is_none()); // no reply
+    fut.expect_pending(); // no reply
 
     // reply with error
     let req_msg           = fixture.transport.expect_json_message::<MockRequestMessage>();
@@ -197,9 +190,7 @@ fn test_error_call() {
     // receive error
     fixture.pool.run_until_stalled();
 
-    let result = poll(&mut fut);
-    let result = result.expect("result should be present");
-    let result = result.expect_err("result should be a failure");
+    let result = fut.expect_err();
     if let RpcError::RemoteError(e) = result {
         assert_eq!(e.code, error_code);
         assert_eq!(e.data, error_data);
@@ -213,12 +204,12 @@ fn test_error_call() {
 fn test_garbage_reply_error() {
     let mut fixture = Fixture::new();
     let mut fut     = Box::pin(fixture.client.pow(8));
-    assert!(poll(&mut fut).is_none()); // no reply
+    fut.expect_pending(); // no reply
     fixture.transport.mock_peer_text_message("hello, nice to meet you");
 
     fixture.pool.run_until_stalled();
 
-    assert!(poll(&mut fut).is_none()); // no valid reply
+    fut.expect_pending(); // no valid reply
     let internal_error = fixture.client.expect_handling_error();
     if let HandlingError::InvalidMessage(_) = internal_error {
     } else {
@@ -230,15 +221,13 @@ fn test_garbage_reply_error() {
 fn test_disconnect_error() {
     let mut fixture = Fixture::new();
     let mut fut     = Box::pin(fixture.client.pow(8));
-    assert!(poll(&mut fut).is_none()); // no reply nor relevant event
+    fut.expect_pending(); // no reply nor relevant event
     fixture.transport.mock_connection_closed();
-    assert!(poll(&mut fut).is_none()); // closing event not yet processed
+    fut.expect_pending(); // closing event not yet processed
 
     fixture.pool.run_until_stalled();
 
-    let result = poll(&mut fut);
-    let result = result.expect("result should be present");
-    let result = result.expect_err("result should be a failure");
+    let result = fut.expect_err();
     if let RpcError::LostConnection = result {} else {
         panic!("Expected an error to be RemoteError");
     }
@@ -249,22 +238,19 @@ fn test_sending_while_disconnected() {
     let mut fixture = Fixture::new();
     fixture.transport.mock_connection_closed();
     let mut fut = Box::pin(fixture.client.pow(8));
-    let result  = poll(&mut fut).unwrap();
-    assert!(result.is_err())
+    fut.expect_err();
 }
 
 fn test_notification(mock_notif:MockNotification) {
     let mut fixture = Fixture::new();
     let message     = Message::new(mock_notif.clone());
-    assert!(fixture.client.try_get_notification().is_none());
+    fixture.client.events_stream.expect_pending();
     fixture.transport.mock_peer_json_message(message.clone());
-    assert!(fixture.client.try_get_notification().is_none());
-
+    fixture.client.events_stream.expect_pending();
     fixture.pool.run_until_stalled();
 
-    let notification = fixture.client.try_get_notification();
-    assert_eq!(notification.is_none(), false);
-    assert_eq!(notification, Some(mock_notif));
+    let notification = fixture.client.expect_notification();
+    assert_eq!(notification,mock_notif);
 }
 
 #[test]
@@ -285,9 +271,9 @@ fn test_handling_invalid_notification() {
     }"#;
 
     let mut fixture = Fixture::new();
-    assert!(fixture.client.try_get_notification().is_none());
+    fixture.client.expect_no_notification_yet();
     fixture.transport.mock_peer_text_message(other_notification);
-    assert!(fixture.client.try_get_notification().is_none());
+    fixture.client.expect_no_notification_yet();
 
     fixture.pool.run_until_stalled();
 

--- a/src/rust/ide/utils/src/test.rs
+++ b/src/rust/ide/utils/src/test.rs
@@ -1,71 +1,14 @@
 //! Module with general purpose utilities meant to be used in tests.
 
-use futures::Stream;
+pub mod future;
+pub mod stream;
 
-use std::future::Future;
-use std::fmt::Debug;
-use std::ops::DerefMut;
-use std::pin::Pin;
-use std::task::Context;
-use std::task::Poll;
-
-
-
-// ======================
-// === Task Execution ===
-// ======================
-
-/// Polls the future, performing any available work.
-///
-/// If future is complete, returns result. Otherwise, returns control when
-/// stalled.
-/// It is not legal to call this on future that already completed.
-pub fn poll<F,R>(fut:&mut Pin<F>) -> Option<R>
-where F:DerefMut<Target:Future<Output=R>> {
-    let mut ctx = std::task::Context::from_waker(futures::task::noop_waker_ref());
-    match fut.as_mut().poll(&mut ctx) {
-        std::task::Poll::Ready(result) => Some(result),
-        std::task::Poll::Pending       => None,
-    }
-}
-
-/// Polls the future and asserts that the result remains not available yet.
-pub fn expect_not_ready<F,R>(fut:&mut Pin<F>)
-where F:DerefMut<Target:Future<Output=R>> {
-    assert!(poll(fut).is_none(), "expected future to not be ready")
-}
-
-/// Polls the future and asserts that the result is available yet - and returns it.
-pub fn expect_ready<F,R>(fut:&mut Pin<F>) -> R
-where F:DerefMut<Target:Future<Output=R>> {
-    poll(fut).expect("expected future to be ready")
-}
-
-/// Polls the future and asserts that the result is Ok(_) - and returns it after unwrapping.
-pub fn expect_ok<F,R,E>(fut:&mut Pin<F>) -> R
-where F:DerefMut<Target:Future<Output=Result<R,E>>>,
-          E:Debug {
-    expect_ready(fut).expect("expected future to yield an Ok(_) result")
-}
-
-/// Polls the future and asserts that the result is Err(_) - and returns the error after unwrapping.
-pub fn expect_err<F,R,E>(fut:&mut Pin<F>) -> E
-where F:DerefMut<Target:Future<Output=Result<R,E>>>,
-          R:Debug {
-    expect_ready(fut).expect_err("expected future to yield an Err(_) result")
-}
-
-/// Polls the stream, performing any available work. If a new value is
-/// ready, returns it.
-///
-/// Note that this API hides the difference between value not being available
-/// yet and stream being finished.
-pub fn poll_stream_output<S : Stream + ?Sized>(f:&mut Pin<Box<S>>) -> Option<S::Item> {
-    let mut ctx = Context::from_waker(futures::task::noop_waker_ref());
-    match f.as_mut().poll_next(&mut ctx) {
-        Poll::Ready(result) => result,
-        Poll::Pending       => None,
-    }
+/// Traits providing helper methods for test code.
+pub mod traits {
+    pub use super::ExpectTuple;
+    pub use super::future::FutureResultTestExt;
+    pub use super::future::FutureTestExt;
+    pub use super::stream::StreamTestExt;
 }
 
 

--- a/src/rust/ide/utils/src/test/future.rs
+++ b/src/rust/ide/utils/src/test/future.rs
@@ -1,0 +1,80 @@
+//! Utilities for dealing with `Future` values in test code.
+
+use crate::prelude::*;
+
+use std::future::Future;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+
+/// Extensions to the `Future` trait allowing manual control of the future execution by subsequent
+/// polling.
+pub trait FutureTestExt<F:Future+?Sized> {
+    /// Access the underlying `Future` in its pinned form, so that it can be `poll`ed.
+    fn get_pinned_future(&mut self) -> Pin<&mut F>;
+
+    /// Polls the future and asserts that the result remains not available yet.
+    ///
+    /// Same caveats apply as for `manual_poll`.
+    fn expect_pending(&mut self) {
+        assert!(self.manual_poll().is_pending());
+    }
+
+    /// Polls the future and asserts that the result is available yet - and returns it.
+    ///
+    /// Same caveats apply as for `manual_poll`.
+    fn expect_ready(&mut self) -> F::Output {
+        if let Poll::Ready(output) = self.manual_poll() {
+            output
+        } else {
+            panic!("The future does not have a ready value.")
+        }
+    }
+
+    /// Polls the future, performing any available work.
+    ///
+    /// If future is complete, returns result. Otherwise, returns control when
+    /// stalled. It is not legal to call this on future that has been already completed.
+    ///
+    /// As this manually polls the future while skipping the executor, the Future won't
+    /// automatically wake up later and may be finished only by subsequent calls to this function.
+    /// As such, this shouldn't be used anywhere except for testing the behavior of the future
+    /// value.
+    fn manual_poll(&mut self) -> Poll<F::Output> {
+        let mut ctx = Context::from_waker(futures::task::noop_waker_ref());
+        self.get_pinned_future().poll(&mut ctx)
+    }
+}
+
+impl<P,F> FutureTestExt<F> for Pin<P>
+where P : Unpin  + DerefMut<Target=F>,
+      F : ?Sized + Future {
+    fn get_pinned_future(&mut self) -> Pin<&mut F> {
+        self.as_mut()
+    }
+}
+
+/// Convenience extensions for testing `Future`s that yields `Result` type.
+pub trait FutureResultTestExt<F,R,E> : FutureTestExt<F>
+where F: ?Sized + Future<Output=Result<R,E>> {
+    /// Polls the future and asserts that the result is Ok(_) - and returns it after unwrapping.
+    ///
+    /// Same caveats apply as for `manual_poll`.
+    fn expect_ok(&mut self) -> R
+    where E:Debug {
+        self.expect_ready().expect("Expected future to yield an Ok(_) result.")
+    }
+
+    /// Polls the future and asserts that the result is Err(_) - and returns the error after
+    /// unwrapping.
+    ///
+    /// Same caveats apply as for `manual_poll`.
+    fn expect_err(&mut self) -> E
+        where R:Debug {
+        self.expect_ready().expect_err("Expected future to yield an Err(_) result.")
+    }
+}
+
+impl<T,F,R,E> FutureResultTestExt<F,R,E> for T
+where T : FutureTestExt<F>,
+      F : ?Sized + Future<Output=Result<R,E>> {}

--- a/src/rust/ide/utils/src/test/stream.rs
+++ b/src/rust/ide/utils/src/test/stream.rs
@@ -1,0 +1,67 @@
+//! Utilities for dealing with `Stream` values in test code.
+
+use crate::prelude::*;
+
+use futures::Stream;
+use std::pin::Pin;
+use std::task::Context;
+use std::task::Poll;
+
+/// Extensions to the `Stream` trait allowing manual control of the execution by subsequent
+/// polling.
+pub trait StreamTestExt<S:?Sized + Stream> {
+    /// Access the underlying `Stream` in its pinned form, so that it can be `poll`ed.
+    fn get_pinned_stream(&mut self) -> Pin<&mut S>;
+
+    /// Polls the stream, performing any available work. If a new value is ready, returns it.
+    ///
+    /// The stream polled with this method might not be properly waken later.
+    /// Once stream finishes, this method must not be called again (unless stream is fused).
+    fn manual_poll_next(&mut self) -> Poll<Option<S::Item>> {
+        let mut ctx = Context::from_waker(futures::task::noop_waker_ref());
+        self.get_pinned_stream().poll_next(&mut ctx)
+    }
+
+    /// Asserts that stream has next value ready and returns it.
+    ///
+    /// Same caveats apply as for `test_poll_next`.
+    fn expect_next(&mut self) -> S::Item {
+        match self.manual_poll_next() {
+            Poll::Pending           => panic!("Stream has no next item available yet."),
+            Poll::Ready(Some(item)) => item,
+            Poll::Ready(None)       => panic!("Stream ended instead of yielding an expected value.")
+        }
+    }
+
+    /// Asserts that stream has terminated.
+    ///
+    /// Same caveats apply as for `test_poll_next`.
+    fn expect_terminated(&mut self) {
+        match self.manual_poll_next() {
+            Poll::Ready(None) => {}
+            _                 => panic!("Stream has not terminated."),
+        }
+    }
+
+    /// Asserts that the next value in the stream is not ready yet.
+    ///
+    /// Same caveats apply as for `test_poll_next`.
+    fn expect_pending(&mut self)
+    where S::Item:Debug {
+        match self.manual_poll_next() {
+            Poll::Pending           => {}
+            Poll::Ready(Some(item)) =>
+                panic!("There should be no value ready, yet the stream yielded {:?}",item),
+            Poll::Ready(None) =>
+                panic!("Stream has terminated, while it should be waiting for the next value."),
+        }
+    }
+}
+
+impl<P,S> StreamTestExt<S> for Pin<P>
+where P : Unpin  + DerefMut<Target=S>,
+          S : ?Sized + Stream {
+    fn get_pinned_stream(&mut self) -> Pin<&mut S> {
+        self.as_mut()
+    }
+}

--- a/src/rust/ide/utils/src/test/stream.rs
+++ b/src/rust/ide/utils/src/test/stream.rs
@@ -60,7 +60,7 @@ pub trait StreamTestExt<S:?Sized + Stream> {
 
 impl<P,S> StreamTestExt<S> for Pin<P>
 where P : Unpin  + DerefMut<Target=S>,
-          S : ?Sized + Stream {
+      S : ?Sized + Stream {
     fn get_pinned_stream(&mut self) -> Pin<&mut S> {
         self.as_mut()
     }


### PR DESCRIPTION
### Pull Request Description
This PR refactors the functions to test Futures and Streams into extension traits for nicer syntax. Also added a few more and improved documentation.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.

