### PR TITLE
Hotfix for TextField resizing

### DIFF
--- a/src/rust/ensogl/src/display/shape/text/text_field.rs
+++ b/src/rust/ensogl/src/display/shape/text/text_field.rs
@@ -146,6 +146,12 @@ shared! { TextField
             self.properties.size
         }
 
+        /// Set size.
+        pub fn set_size(&mut self, size:Vector2<f32>) {
+            self.properties.size = size;
+            self.rendered.update_lines(&self.properties);
+        }
+
         /// Scroll text by given offset in pixels.
         pub fn scroll(&mut self, offset:Vector2<f32>) {
             let scroll_position = self.scroll_position();

--- a/src/rust/ensogl/src/display/shape/text/text_field/render.rs
+++ b/src/rust/ensogl/src/display/shape/text/text_field/render.rs
@@ -61,7 +61,7 @@ pub struct TextFieldSprites {
     pub cursors: Vec<CursorSprites>,
     /// Current assignment of glyph lines to actual lines of text.
     pub assignment: GlyphLinesAssignment,
-    /// line height in pixels.
+    /// Line height in pixels.
     pub line_height: f32,
     /// Display object of the whole rendered content.
     pub display_object: display::object::Instance,
@@ -76,7 +76,6 @@ impl TextFieldSprites {
     pub fn new(world:&World, properties:&TextFieldProperties) -> Self {
         let font              = properties.font.clone_ref();
         let line_height       = properties.text_size;
-        let window_size       = properties.size;
         let color             = properties.base_color;
         let selection_system  = Self::create_selection_system(world);
         let cursor_system     = Self::create_cursor_system(world,line_height,color);
@@ -87,20 +86,39 @@ impl TextFieldSprites {
         display_object.add_child(&glyph_system);
         display_object.add_child(&cursor_system);
 
-        let assignment        = Self::create_assignment_structure(window_size,line_height,font);
-        let glyph_lines_count = assignment.glyph_lines_count();
-        let length            = assignment.max_glyphs_in_line;
-        let indexes     = 0..glyph_lines_count;
-        let glyph_lines = indexes.map(|_| {
-            let line = glyph_system.new_line();
-            line.set_font_size(line_height);
-            line.set_font_color(color);
-            line.set_fixed_capacity(length);
+        let assignment  = default();
+        let glyph_lines = default();
+        TextFieldSprites {glyph_system,cursor_system,selection_system,glyph_lines,cursors,
+            line_height,display_object,assignment}.initialize(properties)
+    }
+
+    fn initialize(mut self, properties:&TextFieldProperties) -> Self {
+        self.update_lines(properties);
+        self
+    }
+
+    /// Update the count and length of rendered lines according to the given properties.
+    // TODO this is done in quite uneffective way, as a hot fix for resing TextField.
+    //  see the issue #177
+    pub fn update_lines(&mut self, properties:&TextFieldProperties) {
+        let font              = properties.font.clone_ref();
+        let line_height       = properties.text_size;
+        let window_size       = properties.size;
+        self.assignment       = Self::create_assignment_structure(window_size,line_height,font);
+        let glyph_lines_count = self.assignment.glyph_lines_count();
+        let length            = self.assignment.max_glyphs_in_line;
+        let system            = &self.glyph_system;
+        let display_object    = &self.display_object;
+        self.glyph_lines.resize_with(glyph_lines_count,|| {
+            let line = system.new_line();
             display_object.add_child(&line);
             line
-        }).collect();
-        TextFieldSprites {glyph_system,cursor_system,selection_system,glyph_lines,cursors,
-            line_height,display_object,assignment}
+        });
+        for line in &mut self.glyph_lines {
+            line.set_font_size(line_height);
+            line.set_font_color(properties.base_color);
+            line.set_fixed_capacity(length);
+        }
     }
 
     fn create_cursor_system(world:&World,line_height:f32,color:color::Rgba) -> ShapeSystem {

--- a/src/rust/ensogl/src/display/shape/text/text_field/render.rs
+++ b/src/rust/ensogl/src/display/shape/text/text_field/render.rs
@@ -98,8 +98,8 @@ impl TextFieldSprites {
     }
 
     /// Update the count and length of rendered lines according to the given properties.
-    // TODO this is done in quite uneffective way, as a hot fix for resing TextField.
-    //  see the issue #177
+    // TODO [ao] This is done in quite uneffective way, as a hot fix for resing TextField.
+    //  See the issue https://github.com/luna/ide/issues/177
     pub fn update_lines(&mut self, properties:&TextFieldProperties) {
         let font              = properties.font.clone_ref();
         let line_height       = properties.text_size;

--- a/src/rust/ensogl/src/display/shape/text/text_field/render/assignment.rs
+++ b/src/rust/ensogl/src/display/shape/text/text_field/render/assignment.rs
@@ -92,6 +92,19 @@ impl GlyphLinesAssignment {
     }
 }
 
+impl Default for GlyphLinesAssignment {
+    fn default() -> Self {
+        GlyphLinesAssignment {
+            glyph_lines_fragments              : default(),
+            assigned_lines                     : 1..=0,
+            dirty_glyph_lines                  : default(),
+            max_glyphs_in_line                 : default(),
+            x_margin                           : default(),
+            next_glyph_line_to_x_scroll_update : default(),
+        }
+    }
+}
+
 
 // === Assignment update ===
 

--- a/src/rust/ide/src/view/text_editor.rs
+++ b/src/rust/ide/src/view/text_editor.rs
@@ -165,10 +165,8 @@ impl TextEditor {
         let position = data.position;
         let position = Vector3::new(position.x + padding.left,position.y + padding.bottom,z_origin);
         data.text_field.set_position(position);
-        // TODO: Set text field size once the size change gets supported.
-        // https://app.zenhub.com/workspaces/enso-5b57093c92e09f0d21193695/issues/luna/ide/217
-        // let padding  = Vector2::new(padding.left + padding.right, padding.top + padding.bottom);
-        // self.text_field.set_size(self.dimensions - padding);
+        let padding  = Vector2::new(padding.left + padding.right, padding.top + padding.bottom);
+        data.text_field.set_size(data.size - padding);
     }
 }
 


### PR DESCRIPTION
### Pull Request Description
This is a hotfix for a half of the bug with resizing IDE. 

Before the TextField component did not support resizing. The proper way to implement it got stuck, and later there were more importand things to do. However, the issue with resizing IDE must be fixed somehow.

The issues for make textfield properly are #177 #178.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

