### PR TITLE
Change IDE owner to mwu-two

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 * @wdanilo
-src/rust/ide @farmaazon
+src/rust/ide @mwu-tow


### PR DESCRIPTION
I'll be off for the next two weeks, therefore I change the owner of IDE to Michał, so IDE PR-s won't be blocked.
