### PR TITLE
Fix: Mouse cursor has wrong position after scene resize. 

### DIFF
--- a/src/rust/ensogl/src/control/io/mouse.rs
+++ b/src/rust/ensogl/src/control/io/mouse.rs
@@ -101,9 +101,10 @@ macro_rules! define_bindings {
                 let dispatchers = MouseManagerDispatchers::default();
                 let dom         = dom.clone();
                 $(
+                    let shape      = dom.shape().clone_ref();
                     let dispatcher = dispatchers.$name.clone_ref();
-                    let shape      = dom.shape().current();
                     let $name : MouseEventJsClosure = Closure::wrap(Box::new(move |event:JsValue| {
+                        let shape = shape.current();
                         let event = event.unchecked_into::<web_sys::$js_event>();
                         dispatcher.dispatch(&event::$target::new(event,shape))
                     }));
@@ -140,6 +141,7 @@ pub struct MouseFrpCallbackHandles {
 /// Bind FRP graph to MouseManager.
 pub fn bind_frp_to_mouse(frp:&enso_frp::io::Mouse, mouse_manager:&MouseManager)
 -> MouseFrpCallbackHandles {
+    // TODO: This does not seem to be ever used. Can it be removed?
     let on_move = enclose!((frp.position => frp) move |e:&OnMove| {
         frp.emit(Position::new(e.client_x() as f32,e.client_y() as f32));
     });


### PR DESCRIPTION
 Use the up to date scene shape data to calculate mouse event positions.

The previous version would move the actual shape data of the scene (`shape`) on initialization into the closure that instantiates mouse events. From then on all mouse events were initialized with this data and their positions calculated based on this data. When the scene size changed, this would go out of sync with the actual scene shape and the position of our mouse cursor would no longer align with the actual position of the system cursor.

### Pull Request Description

The fix is to move a handle into the closure that allows access to the up-to-date scene shape data at any time instead of the actual data.


### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

