### PR TITLE
Extend graph editor api to allow data to be set on visualizations and stream the visibility status of visualisations.

### DIFF
--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -283,7 +283,7 @@ impl NodeModel {
         let scene = scene.clone_ref();
         let input = InputEvents::new(&network);
 
-        let visualization_container = visualization::Container::new();
+        let visualization_container = visualization::Container::new(&scene);
         visualization_container.mod_position(|t| {
             t.x = 60.0;
             t.y = -120.0;

--- a/src/rust/lib/graph-editor/src/component/visualization/container.rs
+++ b/src/rust/lib/graph-editor/src/component/visualization/container.rs
@@ -84,7 +84,7 @@ impl ContainerData {
     }
 
     /// Indicates whether the visualization is visible.
-    fn is_visible(&self) -> bool {
+    pub fn is_visible(&self) -> bool {
         if let Some(vis) = self.visualization.borrow().as_ref() {
             vis.has_parent()
         } else {

--- a/src/rust/lib/graph-editor/src/component/visualization/container.rs
+++ b/src/rust/lib/graph-editor/src/component/visualization/container.rs
@@ -5,9 +5,9 @@ use crate::prelude::*;
 use crate::frp;
 use crate::visualization::*;
 
+use ensogl::display::Scene;
 use ensogl::display::traits::*;
 use ensogl::display;
-
 
 
 // ===========
@@ -125,13 +125,15 @@ impl display::Object for ContainerData {
 
 impl Container {
     /// Constructor.
-    pub fn new() -> Self {
+    pub fn new(scene:&Scene) -> Self {
         let logger         = Logger::new("visualization");
         let visualization  = default();
         let size           = Cell::new(Vector2::new(100.0, 100.0));
         let display_object = display::object::Instance::new(&logger);
         let data           = ContainerData {logger,visualization,size,display_object};
         let data           = Rc::new(data);
+        data.set_visualization(Registry::default_visualisation(&scene));
+        data.set_visibility(false);
         let frp            = default();
         Self {data,frp} . init_frp()
     }
@@ -164,12 +166,6 @@ impl Container {
             }));
         }
         self
-    }
-}
-
-impl Default for Container {
-    fn default() -> Self {
-        Container::new()
     }
 }
 

--- a/src/rust/lib/graph-editor/src/component/visualization/registry.rs
+++ b/src/rust/lib/graph-editor/src/component/visualization/registry.rs
@@ -99,4 +99,17 @@ impl Registry {
         let entries       = self.entries.borrow();
         entries.get(dtype).cloned().unwrap_or_else(default)
     }
+
+    /// Return a default visualisation class.
+    pub fn default_visualisation(scene:&Scene) -> Visualization {
+        // TODO replace with RawText visualisation.
+       let class = Rc::new(NativeConstructorClass::new(
+            Signature {
+                name        : "Bubble Visualization (native)".to_string(),
+                input_types : vec!["[[Float,Float,Float]]".to_string().into()],
+            },
+            |scene:&Scene| Ok(Visualization::new(BubbleChart::new(scene)))
+        ));
+        class.instantiate(&scene).expect("Failed to instantiate default visualisation")
+    }
 }

--- a/src/rust/lib/graph-editor/src/component/visualization/registry.rs
+++ b/src/rust/lib/graph-editor/src/component/visualization/registry.rs
@@ -109,14 +109,13 @@ impl Registry {
 
     /// Return a default visualisation class.
     pub fn default_visualisation(scene:&Scene) -> Visualization {
-        // TODO replace with RawText visualisation.
-       let class = Rc::new(NativeConstructorClass::new(
+        let class = NativeConstructorClass::new(
             Signature {
-                name        : "Bubble Visualization (native)".to_string(),
+                name        : "Raw Text Visualization (native)".to_string(),
                 input_types : vec!["[[Float,Float,Float]]".to_string().into()],
             },
-            |scene:&Scene| Ok(Visualization::new(BubbleChart::new(scene)))
-        ));
+            |scene:&Scene| Ok(Visualization::new(RawText::new(scene)))
+        );
         class.instantiate(&scene).expect("Failed to instantiate default visualisation")
     }
 }

--- a/src/rust/lib/graph-editor/src/component/visualization/renderer/example/native.rs
+++ b/src/rust/lib/graph-editor/src/component/visualization/renderer/example/native.rs
@@ -65,7 +65,7 @@ impl DataRenderer for BubbleChart {
 
     fn receive_data(&self, data:Data) -> Result<(),DataError> {
         let data_inner: Rc<Vec<Vector3<f32>>> = data.as_binary()?;
-
+        println!("DATA");
         // Avoid re-creating views, if we have already created some before.
         let mut views = self.views.borrow_mut();
         views.resize_with(data_inner.len(),|| component::ShapeView::new(&self.logger,&self.scene));

--- a/src/rust/lib/graph-editor/src/component/visualization/renderer/example/native.rs
+++ b/src/rust/lib/graph-editor/src/component/visualization/renderer/example/native.rs
@@ -65,7 +65,6 @@ impl DataRenderer for BubbleChart {
 
     fn receive_data(&self, data:Data) -> Result<(),DataError> {
         let data_inner: Rc<Vec<Vector3<f32>>> = data.as_binary()?;
-        println!("DATA");
         // Avoid re-creating views, if we have already created some before.
         let mut views = self.views.borrow_mut();
         views.resize_with(data_inner.len(),|| component::ShapeView::new(&self.logger,&self.scene));

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -1568,10 +1568,8 @@ fn new_graph_editor(world:&World) -> GraphEditor {
                 node.view.visualization_container.frp.toggle_visibility.emit(());
                 if node.view.visualization_container.is_visible() {
                     inputs.on_visualization_enabled.emit(node_id);
-                    println!("on_visualization_enabled");
                 } else {
                     inputs.on_visualization_disabled.emit(node_id);
-                    println!("on_visualization_disabled");
                 }
             }
         });

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -503,6 +503,9 @@ generate_frp_outputs! {
 
     connection_added    : EdgeId,
     connection_removed  : EdgeId,
+
+    visualization_enabled  : NodeId,
+    visualization_disabled : NodeId,
 }
 
 

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -1568,8 +1568,10 @@ fn new_graph_editor(world:&World) -> GraphEditor {
                 node.view.visualization_container.frp.toggle_visibility.emit(());
                 if node.view.visualization_container.is_visible() {
                     inputs.on_visualization_enabled.emit(node_id);
+                    println!("on_visualization_enabled");
                 } else {
                     inputs.on_visualization_disabled.emit(node_id);
+                    println!("on_visualization_disabled");
                 }
             }
         });

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -360,7 +360,7 @@ pub struct FrpInputs {
     pub cycle_visualization          : frp::Source<NodeId>,
     pub set_visualization            : frp::Source<(NodeId,Option<Visualization>)>,
     pub register_visualization_class : frp::Source<Option<Rc<visualization::Handle>>>,
-     pub set_visualization_data       : frp::Source<(NodeId,Option<visualization::Data>)>,
+    pub set_visualization_data       : frp::Source<(NodeId,Option<visualization::Data>)>,
 
     hover_node_input           : frp::Source<Option<EdgeTarget>>,
     some_edge_targets_detached : frp::Source,

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -360,9 +360,7 @@ pub struct FrpInputs {
     pub cycle_visualization          : frp::Source<NodeId>,
     pub set_visualization            : frp::Source<(NodeId,Option<Visualization>)>,
     pub register_visualization_class : frp::Source<Option<Rc<visualization::Handle>>>,
-    pub visualization_enabled        : frp::Stream<NodeId>,
-    pub visualization_disabled       : frp::Stream<NodeId>,
-    pub set_visualization_data       : frp::Source<(NodeId,Option<visualization::Data>)>,
+     pub set_visualization_data       : frp::Source<(NodeId,Option<visualization::Data>)>,
 
     hover_node_input           : frp::Source<Option<EdgeTarget>>,
     some_edge_targets_detached : frp::Source,
@@ -403,10 +401,6 @@ impl FrpInputs {
             def on_visualization_enabled  = source();
             def on_visualization_disabled = source();
 
-            let visualization_enabled  = on_visualization_enabled.clone_ref().into();
-            let visualization_disabled = on_visualization_disabled.clone_ref().into();
-
-
         }
         let commands = Commands::new(&network);
         Self {commands,remove_edge,press_node_input,remove_all_node_edges
@@ -416,8 +410,8 @@ impl FrpInputs {
              ,set_node_position,select_node,remove_node,translate_selected_nodes,set_node_expression
              ,connect_nodes,deselect_all_nodes,cycle_visualization,set_visualization
              ,register_visualization_class,some_edge_targets_detached,all_edge_targets_attached
-             ,hover_node_input,visualization_enabled,on_visualization_disabled
-             ,on_visualization_enabled,visualization_disabled
+             ,hover_node_input,on_visualization_disabled
+             ,on_visualization_enabled
              }
     }
 }
@@ -1538,7 +1532,7 @@ fn new_graph_editor(world:&World) -> GraphEditor {
             let data          = Rc::new(sample_data_generator.generate_data());
             let content       = Rc::new(serde_json::to_value(data).unwrap());
             let data          = visualization::Data::JSON{ content };
-            inputs.set_visualization_data.emit((node_id.clone(),Some(data)));
+            inputs.set_visualization_data.emit((*node_id,Some(data)));
         })
     }));
 
@@ -1577,6 +1571,9 @@ fn new_graph_editor(world:&World) -> GraphEditor {
             }
         });
     }));
+
+    outputs.visualization_enabled  <+ inputs.on_visualization_enabled;
+    outputs.visualization_disabled <+ inputs.on_visualization_disabled;
 
     // === Register Visualization ===
 


### PR DESCRIPTION
### Pull Request Description
Adds three new FRP endpoints to the graph editor:

* `visualization_enabled  : Stream<NodeId>`
* `visualization_disabled : Stream<NodeId>`
* `set_visualization_data : Source<(NodeId,Data)>` 

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

