### PR TITLE
Implement segmented output ports.

### DIFF
--- a/build/run.js
+++ b/build/run.js
@@ -127,7 +127,7 @@ commands.build.rust = async function(argv) {
 
         console.log('Checking the resulting WASM size.')
         let stats = fss.statSync(paths.dist.wasm.mainOptGz)
-        let limit = 3.29
+        let limit = 3.31
         let size = Math.round(100 * stats.size / 1024 / 1024) / 100
         if (size > limit) {
             throw(`Output file size exceeds the limit (${size}MB > ${limit}MB).`)

--- a/src/rust/ensogl/src/display/shape/primitive/def/class.rs
+++ b/src/rust/ensogl/src/display/shape/primitive/def/class.rs
@@ -152,6 +152,11 @@ pub trait ShapeOps : Sized where for<'t> &'t Self : IntoOwned<Owned=Self> {
     fn grow<T:Into<Var<Distance<Pixels>>>>(&self, value:T) -> Grow<Self> {
         Grow(self, value.into())
     }
+
+    /// Shrinks the shape by the given amount.
+    fn shrink<T:Into<Var<Distance<Pixels>>>>(&self, value:T) -> Shrink<Self> {
+        Shrink(self, value.into())
+    }
 }
 
 macro_rules! define_shape_operator {

--- a/src/rust/ensogl/src/display/shape/primitive/def/class.rs
+++ b/src/rust/ensogl/src/display/shape/primitive/def/class.rs
@@ -147,6 +147,11 @@ pub trait ShapeOps : Sized where for<'t> &'t Self : IntoOwned<Owned=Self> {
     fn pixel_snap(&self) -> PixelSnap<Self> {
         PixelSnap(self)
     }
+
+    /// Grows the shape by the given amount.
+    fn grow<T:Into<Var<Distance<Pixels>>>>(&self, value:T) -> Grow<Self> {
+        Grow(self, value.into())
+    }
 }
 
 macro_rules! define_shape_operator {

--- a/src/rust/ensogl/src/display/shape/primitive/def/modifier.rs
+++ b/src/rust/ensogl/src/display/shape/primitive/def/modifier.rs
@@ -123,4 +123,5 @@ define_modifiers! {
     Intersection intersection  (child1,child2) ()
     Fill         fill          (child)         (color:Rgba)
     PixelSnap    pixel_snap    (child)         ()
+    Grow         grow          (child)         (value:f32)
 }

--- a/src/rust/ensogl/src/display/shape/primitive/def/modifier.rs
+++ b/src/rust/ensogl/src/display/shape/primitive/def/modifier.rs
@@ -124,4 +124,5 @@ define_modifiers! {
     Fill         fill          (child)         (color:Rgba)
     PixelSnap    pixel_snap    (child)         ()
     Grow         grow          (child)         (value:f32)
+    Shrink       shrink        (child)         (value:f32)
 }

--- a/src/rust/ensogl/src/display/shape/primitive/def/var.rs
+++ b/src/rust/ensogl/src/display/shape/primitive/def/var.rs
@@ -527,12 +527,12 @@ where T: Clamp<Output=T>+Into<Glsl> {
 
         match (self, lower, upper) {
             (Static(value),Static(lower),Static(upper)) => Static(value.clamp(lower, upper)),
-            (value, lower, upper)                       => Dynamic({
+            (value, lower, upper)                       => {
                 let value:Glsl = value.into();
                 let lower:Glsl = lower.into();
                 let upper:Glsl = upper.into();
-                format!("clamp({},{},{})", value.glsl(), lower.glsl(), upper.glsl()).into()
-            })
+                Dynamic(format!("clamp({},{},{})", value.glsl(), lower.glsl(), upper.glsl()).into())
+            }
         }
     }
 }

--- a/src/rust/ensogl/src/display/shape/primitive/def/var.rs
+++ b/src/rust/ensogl/src/display/shape/primitive/def/var.rs
@@ -6,6 +6,7 @@ use crate::data::color;
 use crate::display::shape::primitive::def::unit::PixelDistance;
 use crate::math::algebra::Acos;
 use crate::math::algebra::Asin;
+use crate::math::algebra::Clamp;
 use crate::math::algebra::Cos;
 use crate::math::algebra::Sin;
 use crate::math::algebra::Sqrt;
@@ -20,7 +21,6 @@ use crate::system::gpu::types::*;
 
 use nalgebra::Scalar;
 use std::ops::*;
-
 
 
 // ======================
@@ -508,6 +508,31 @@ where T: Sqrt<Output=T> {
         match self {
             Self::Static  (t) => Var::Static(t.sqrt()),
             Self::Dynamic (t) => Var::Dynamic(format!("sqrt({})",t).into())
+        }
+    }
+}
+
+
+
+// =============
+// === Clamp ===
+// =============
+
+impl<T> Clamp for Var<T>
+where T: Clamp<Output=T>+Into<Glsl> {
+    type Output = Var<T>;
+    fn clamp(self, lower:Var<T>, upper:Var<T>) -> Var<T> {
+        use Var::Static;
+        use Var::Dynamic;
+
+        match (self, lower, upper) {
+            (Static(value),Static(lower),Static(upper)) => Static(value.clamp(lower, upper)),
+            (value, lower, upper)                       => Dynamic({
+                let value:Glsl = value.into();
+                let lower:Glsl = lower.into();
+                let upper:Glsl = upper.into();
+                format!("clamp({},{},{})", value.glsl(), lower.glsl(), upper.glsl()).into()
+            })
         }
     }
 }

--- a/src/rust/ensogl/src/display/shape/primitive/def/var.rs
+++ b/src/rust/ensogl/src/display/shape/primitive/def/var.rs
@@ -8,6 +8,7 @@ use crate::math::algebra::Acos;
 use crate::math::algebra::Asin;
 use crate::math::algebra::Clamp;
 use crate::math::algebra::Cos;
+use crate::math::algebra::Signum;
 use crate::math::algebra::Sin;
 use crate::math::algebra::Sqrt;
 use crate::math::topology::unit::Angle;
@@ -533,6 +534,23 @@ where T: Clamp<Output=T>+Into<Glsl> {
                 let upper:Glsl = upper.into();
                 Dynamic(format!("clamp({},{},{})", value.glsl(), lower.glsl(), upper.glsl()).into())
             }
+        }
+    }
+}
+
+
+
+// ==============
+// === Signum ===
+// ==============
+
+impl<T> Signum for Var<T>
+    where T: Signum<Output=T> {
+    type Output = Var<T>;
+    fn signum(self) -> Self {
+        match self {
+            Self::Static  (t) => Var::Static(t.signum()),
+            Self::Dynamic (t) => Var::Dynamic(format!("sign({})",t).into())
         }
     }
 }

--- a/src/rust/ensogl/src/display/shape/primitive/glsl/shape.glsl
+++ b/src/rust/ensogl/src/display/shape/primitive/glsl/shape.glsl
@@ -84,7 +84,9 @@ Sdf difference (Sdf a, Sdf b) {
     return intersection(a,inverse(b));
 }
 
-
+Sdf grow (Sdf a, float size) {
+    return Sdf(a.distance - size);
+}
 
 // ================
 // === BoundSdf ===
@@ -133,6 +135,11 @@ BoundSdf resample (BoundSdf a, float multiplier) {
 
 BoundSdf pixel_snap (BoundSdf a) {
     a.distance = floor(a.distance) + 0.5;
+    return a;
+}
+
+BoundSdf grow (BoundSdf a, float size) {
+    a.distance = a.distance - size;
     return a;
 }
 
@@ -239,6 +246,14 @@ Shape resample (Shape s, float multiplier) {
 Shape pixel_snap (Shape s) {
     Id       id    = s.id;
     BoundSdf sdf   = pixel_snap(s.sdf);
+    Srgba    color = unpremultiply(s.color);
+    color.raw.a /= s.alpha;
+    return shape(id,sdf,color);
+}
+
+Shape grow (Shape s, float value) {
+    Id       id    = s.id;
+    BoundSdf sdf   = grow(s.sdf,value);
     Srgba    color = unpremultiply(s.color);
     color.raw.a /= s.alpha;
     return shape(id,sdf,color);

--- a/src/rust/ensogl/src/display/shape/primitive/glsl/shape.glsl
+++ b/src/rust/ensogl/src/display/shape/primitive/glsl/shape.glsl
@@ -140,6 +140,7 @@ BoundSdf pixel_snap (BoundSdf a) {
 
 BoundSdf grow (BoundSdf a, float size) {
     a.distance = a.distance - size;
+    a.bounds   = grow(a.bounds,size);
     return a;
 }
 

--- a/src/rust/ensogl/src/display/shape/primitive/shader/canvas.rs
+++ b/src/rust/ensogl/src/display/shape/primitive/shader/canvas.rs
@@ -292,6 +292,18 @@ impl Canvas {
             shape
         })
     }
+
+    /// Shrink the shape by the given value.
+    pub fn shrink<T:Into<Var<f32>>>
+    (&mut self, num:usize, s:Shape, value:T) -> Shape {
+        self.if_not_defined(num, |this| {
+            let value:Glsl = value.into().glsl();
+            let expr = iformat!("return grow({s.getter()},-{value});");
+            let mut shape = this.new_shape_from_expr(num,&expr);
+            shape.add_ids(&s.ids);
+            shape
+        })
+    }
 }
 
 

--- a/src/rust/ensogl/src/display/shape/primitive/shader/canvas.rs
+++ b/src/rust/ensogl/src/display/shape/primitive/shader/canvas.rs
@@ -280,6 +280,18 @@ impl Canvas {
             shape
         })
     }
+
+    /// Grow the shape by the given value.
+    pub fn grow<T:Into<Var<f32>>>
+    (&mut self, num:usize, s:Shape, value:T) -> Shape {
+        self.if_not_defined(num, |this| {
+            let value:Glsl = value.into().glsl();
+            let expr = iformat!("return grow({s.getter()},{value});");
+            let mut shape = this.new_shape_from_expr(num,&expr);
+            shape.add_ids(&s.ids);
+            shape
+        })
+    }
 }
 
 

--- a/src/rust/ensogl/src/display/shape/primitive/shader/canvas.rs
+++ b/src/rust/ensogl/src/display/shape/primitive/shader/canvas.rs
@@ -263,7 +263,7 @@ impl Canvas {
             let color:Glsl = color.into().glsl();
             this.add_current_function_code_line(iformat!("Shape shape = {s.getter()};"));
             this.add_current_function_code_line(iformat!("Srgba color = srgba({color});"));
-            let expr = iformat!("return set_color(shape,color);");
+            let expr      = iformat!("return set_color(shape,color);");
             let mut shape = this.new_shape_from_expr(num,&expr);
             shape.add_ids(&s.ids);
             shape
@@ -274,7 +274,7 @@ impl Canvas {
     pub fn pixel_snap
     (&mut self, num:usize, s:Shape) -> Shape {
         self.if_not_defined(num, |this| {
-            let expr = iformat!("return pixel_snap({s.getter()});");
+            let expr      = iformat!("return pixel_snap({s.getter()});");
             let mut shape = this.new_shape_from_expr(num,&expr);
             shape.add_ids(&s.ids);
             shape
@@ -286,8 +286,8 @@ impl Canvas {
     (&mut self, num:usize, s:Shape, value:T) -> Shape {
         self.if_not_defined(num, |this| {
             let value:Glsl = value.into().glsl();
-            let expr = iformat!("return grow({s.getter()},{value});");
-            let mut shape = this.new_shape_from_expr(num,&expr);
+            let expr       = iformat!("return grow({s.getter()},{value});");
+            let mut shape  = this.new_shape_from_expr(num,&expr);
             shape.add_ids(&s.ids);
             shape
         })
@@ -296,13 +296,8 @@ impl Canvas {
     /// Shrink the shape by the given value.
     pub fn shrink<T:Into<Var<f32>>>
     (&mut self, num:usize, s:Shape, value:T) -> Shape {
-        self.if_not_defined(num, |this| {
-            let value:Glsl = value.into().glsl();
-            let expr = iformat!("return grow({s.getter()},-{value});");
-            let mut shape = this.new_shape_from_expr(num,&expr);
-            shape.add_ids(&s.ids);
-            shape
-        })
+        let value = value.into();
+        self.grow(num, s, -value)
     }
 }
 

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -24,7 +24,7 @@ use ensogl::gui::component;
 
 use super::edge;
 use crate::component::visualization;
-use crate::component::node::port::output::OutPutPorts;
+use crate::component::node::port::output::OutputPorts;
 
 
 pub const NODE_SHAPE_PADDING : f32 = 40.0;
@@ -215,7 +215,7 @@ impl NodeModel {
         let logger  = Logger::new("node");
         edge::sort_hack_1(scene);
 
-        OutPutPorts::order_hack(&scene);
+        OutputPorts::order_hack(&scene);
         let main_logger = Logger::sub(&logger,"main_area");
         let drag_logger = Logger::sub(&logger,"drag_area");
         let main_area   = component::ShapeView::<shape      ::Shape>::new(&main_logger  ,scene);
@@ -283,8 +283,8 @@ impl NodeModel {
         let height = self.height();
 
         let size = Vector2::new(width+NODE_SHAPE_PADDING*2.0, height+NODE_SHAPE_PADDING*2.0);
-        self.main_area.shape.sprite.size().set(size);
-        self.drag_area.shape.sprite.size().set(size);
+        self.main_area.shape.sprite.size.set(size);
+        self.drag_area.shape.sprite.size.set(size);
         self.main_area.mod_position(|t| t.x = width/2.0);
         self.main_area.mod_position(|t| t.y = height/2.0);
         self.drag_area.mod_position(|t| t.x = width/2.0);

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -288,7 +288,7 @@ impl NodeModel {
         self.drag_area.mod_position(|t| t.x = width/2.0);
         self.drag_area.mod_position(|t| t.y = height/2.0);
 
-        self.output_ports.frp.set_size.emit(Some(size));
+        self.output_ports.frp.set_size.emit(V2::from(size));
         self.output_ports.mod_position(|t| t.x = width/2.0);
         self.output_ports.mod_position(|t| t.y = height/2.0);
     }

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -297,7 +297,7 @@ impl NodeModel {
         self.drag_area.mod_position(|t| t.x = width/2.0);
         self.drag_area.mod_position(|t| t.y = height/2.0);
 
-        self.output_ports.frp.set_size.emit(V2::from(size));
+        self.output_ports.frp.set_size.emit(size);
         self.output_ports.mod_position(|t| t.x = width/2.0);
         self.output_ports.mod_position(|t| t.y = height/2.0);
     }

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -94,7 +94,7 @@ pub mod shape {
             let select         = select2 - select;
             let select         = select.fill(color::Rgba::from(selection_color));
 
-            let out = select + shape + shadow;
+            let out = select + shadow + shape;
             out.into()
         }
     }

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -215,7 +215,7 @@ impl NodeModel {
         let logger  = Logger::new("node");
         edge::sort_hack_1(scene);
 
-        OutPutPorts::init_shape_order_hack(&scene);
+        OutPutPorts::order_hack(&scene);
         let main_logger = Logger::sub(&logger,"main_area");
         let drag_logger = Logger::sub(&logger,"drag_area");
         let main_area   = component::ShapeView::<shape      ::Shape>::new(&main_logger  ,scene);

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -27,8 +27,8 @@ use crate::component::visualization;
 use crate::component::node::port::output::OutPutPorts;
 
 
-pub(crate) const NODE_SHAPE_PADDING : f32 = 40.0;
-pub(crate) const NODE_SHAPE_RADIUS  : f32 = 14.0;
+pub const NODE_SHAPE_PADDING : f32 = 40.0;
+pub const NODE_SHAPE_RADIUS  : f32 = 14.0;
 
 
 // ============

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -87,7 +87,7 @@ pub mod shape {
             let select         = select2 - select;
             let select         = select.fill(color::Rgba::from(selection_color));
 
-            let out = select + shape;
+            let out = select + shape + shadow;
             out.into()
         }
     }
@@ -254,7 +254,7 @@ impl NodeModel {
 
 
         // TODO: Determine number of output ports based on node semantics.
-        let output_ports = OutputPorts::new(&scene, 4);
+        let output_ports = OutputPorts::new(&scene, 1);
         display_object.add_child(&output_ports);
 
 

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -9,8 +9,8 @@ pub use port::Expression;
 
 use crate::prelude::*;
 
-use enso_frp;
 use enso_frp as frp;
+use enso_frp;
 use ensogl::data::color;
 use ensogl::display::Attribute;
 use ensogl::display::Buffer;
@@ -21,14 +21,21 @@ use ensogl::display::traits::*;
 use ensogl::display;
 use ensogl::gui::component::Animation;
 use ensogl::gui::component;
+use std::num::NonZeroU32;
 
 use super::edge;
 use crate::component::visualization;
 use crate::component::node::port::output::OutputPorts;
 
 
+
+// =================
+// === Constants ===
+// =================
+
 pub const NODE_SHAPE_PADDING : f32 = 40.0;
 pub const NODE_SHAPE_RADIUS  : f32 = 14.0;
+
 
 
 // ============
@@ -254,7 +261,7 @@ impl NodeModel {
 
 
         // TODO: Determine number of output ports based on node semantics.
-        let output_ports = OutputPorts::new(&scene, 20);
+        let output_ports = OutputPorts::new(&scene, NonZeroU32::new(10).unwrap());
         display_object.add_child(&output_ports);
 
 

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -254,7 +254,7 @@ impl NodeModel {
 
 
         // TODO: Determine number of output ports based on node semantics.
-        let output_ports = OutputPorts::new(&scene, 1);
+        let output_ports = OutputPorts::new(&scene, 20);
         display_object.add_child(&output_ports);
 
 

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -254,7 +254,7 @@ impl NodeModel {
 
 
         // TODO: Determine number of output ports based on node semantics.
-        let output_ports = OutputPorts::new(&scene, 10);
+        let output_ports = OutputPorts::new(&scene, 4);
         display_object.add_child(&output_ports);
 
 

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -28,6 +28,7 @@ use crate::component::node::port::output::OutPutPorts;
 
 
 pub(crate) const NODE_SHAPE_PADDING : f32 = 40.0;
+pub(crate) const NODE_SHAPE_RADIUS  : f32 = 14.0;
 
 
 // ============
@@ -50,7 +51,7 @@ pub mod shape {
             let height : Var<Distance<Pixels>> = "input_size.y".into();
             let width  = width  - NODE_SHAPE_PADDING.px() * 2.0;
             let height = height - NODE_SHAPE_PADDING.px() * 2.0;
-            let radius = 14.px();
+            let radius = NODE_SHAPE_RADIUS.px();
             let shape  = Rect((&width,&height)).corners_radius(radius);
             let shape  = shape.fill(color::Rgba::from(bg_color));
 

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -253,6 +253,7 @@ impl NodeModel {
         let frp = Frp{input};
 
 
+        // TODO: Determine number of output ports based on node semantics.
         let output_ports = OutputPorts::new(&scene, 5);
         display_object.add_child(&output_ports);
 

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -87,7 +87,7 @@ pub mod shape {
             let select         = select2 - select;
             let select         = select.fill(color::Rgba::from(selection_color));
 
-            let out = select + shadow + shape;
+            let out = select + shape;
             out.into()
         }
     }

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -254,7 +254,7 @@ impl NodeModel {
 
 
         // TODO: Determine number of output ports based on node semantics.
-        let output_ports = OutputPorts::new(&scene, 5);
+        let output_ports = OutputPorts::new(&scene, 10);
         display_object.add_child(&output_ports);
 
 

--- a/src/rust/lib/graph-editor/src/component/node/port.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port.rs
@@ -1,5 +1,6 @@
 //! Definition of the Port component.
 
+#[warn(missing_docs)]
 pub mod output;
 
 use crate::prelude::*;

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -410,6 +410,24 @@ impl display::Object for ShapeView {
 
 
 
+// ===============
+// === PortId  ===
+// ===============
+
+/// Id of a specific port inside of `OutPutPortsData`.
+#[derive(Clone,Copy,Default,Debug,Eq,PartialEq)]
+pub struct PortId {
+    index: usize,
+}
+
+impl PortId {
+    fn new(index:usize) -> Self {
+        Self{index}
+    }
+}
+
+
+
 // =================
 // === Port Frp  ===
 // =================
@@ -484,18 +502,6 @@ fn init_port_frp<Shape: PortShape +CloneRef+'static>
 // ===========
 // === Frp ===
 // ===========
-
-/// Id of a specific port inside of `OutPutPortsData`.
-#[derive(Clone,Copy,Default,Debug,Eq,PartialEq)]
-pub struct PortId {
-    index: usize,
-}
-
-impl PortId {
-    fn new(index:usize) -> Self {
-        Self{index}
-    }
-}
 
 /// Frp API of the `OutPutPorts`.
 #[derive(Clone,CloneRef,Debug)]

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -15,6 +15,7 @@ use ensogl::gui::component::Animation;
 use ensogl::gui::component;
 
 use crate::node::NODE_SHAPE_PADDING;
+use crate::node::NODE_SHAPE_RADIUS;
 
 
 
@@ -53,7 +54,7 @@ pub mod port_area {
             let hover_area        = hover_area.fill(color::Rgba::new(0.0,0.0,0.0,0.000_001));
 
             let shrink           = 1.px() - 1.px() * &grow;
-            let radius           = 14.px();
+            let radius           = NODE_SHAPE_RADIUS.px();
             let port_area_size   = 4.0.px() * &grow;
             let port_area_width  = &width  + (&port_area_size - &shrink) * 2.0;
             let port_area_height = &height + (&port_area_size - &shrink) * 2.0;

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -19,6 +19,7 @@ use ensogl::math::algebra::Clamp;
 use crate::node;
 
 
+
 // =================
 // === Constants ===
 // =================
@@ -31,15 +32,37 @@ const SEGMENT_GAP_WIDTH   : f32 = 2.0;
 const SHOW_DELAY_DURATION : f32 = 150.0;
 const HIDE_DELAY_DURATION : f32 = 150.0;
 
-const PORT_AREA_WIDTH     : f32  = 4.0;
+
 
 // ==============
 // === Shapes ===
 // ==============
 
-/// The port area shape is based on a single shape that gets offset to show a different slice for
-/// each segment. Each shapes represents a window of the underlying shape.
-pub mod port_area {
+/// Helper trait that allows us to abstract the API of the `multi_port_area::Shape` and the
+/// `single_port_area::Shape`. This is needed to avoid code duplication for functionality that can
+/// work with either shape.
+#[allow(missing_docs)]
+trait PortShapeApi {
+    fn set_grow(&self, grow_value:f32);
+    fn set_opacity(&self, opacity:f32);
+}
+
+/// The port area shape is based on a single shape that gets cropped to show the appropriate
+/// segment.
+///
+/// The base shape looks roughly like this:
+/// ```text
+///      .                            .
+///      .                            .
+///       .                          .
+///          .                    .
+///              """""""""""""
+///     |  r    |              |   r   |
+///     |            width             |
+/// ```
+/// where r is the radius of the left and right quarter circle shapes.
+///
+pub mod multi_port_area {
     use super::*;
     use ensogl::display::shape::*;
     use std::f32::consts::PI;
@@ -54,59 +77,63 @@ pub mod port_area {
         Var::<f32>::from(format!("(step(float({1}),float({0})) * step(float({0}),float({2})))", value, lower_bound, upper_bound))
     }
 
+    /// Compute the rotation of the plane along the shape border. The plane needs to be rotated
+    /// to be perpendicular with the outer shape border. That means, it needs to be rotate in the
+    /// segments that have a curved path, and needs to be perpendicular in the inner segment.
     fn compute_crop_plane_angle(full_shape_border_length:&Var<f32>, corner_segment_length:&Var<f32>, position:&Var<f32>) ->Var<f32> {
-        // TODO implement proper abstraction for non-branching "if/then/else" or "case" ins shaderland
+        // TODO implement proper abstraction for non-branching "if/then/else" or "case" in shaderland
+        // Here we use a trick to use a pseudo-boolean float that is either 0 or 1 to multiply a
+        // value that should be returned, iff it's case is true. That way we can add return values
+        // of different "branches" of which exactly one will be non-zero.
+
         let start                      = 0.0.into();
         let middle_segment_start_point = corner_segment_length;
         let middle_segment_end_point   = full_shape_border_length - corner_segment_length;
         let end                        = full_shape_border_length;
 
-        let base_rotation = Var::<f32>::from(90.0_f32.to_radians());
+        let default_rotation           = Var::<f32>::from(90.0_f32.to_radians());
 
-        // Case 1:
-        let case_1            = in_range(position, &start, &middle_segment_start_point);
-        let case_1_value_base = Var::<f32>::from(1.0) - (position / corner_segment_length).clamp(0.0.into(), 1.0.into());
-        let case_1_scale      = 90.0_f32.to_radians();
-        let case_1_value      = case_1 * (case_1_value_base * case_1_scale + &base_rotation);
+        let case_1_pseudo_bool      = in_range(position, &start, &middle_segment_start_point);
+        let case_1_value_normalised = Var::<f32>::from(1.0) - (position / corner_segment_length).clamp(0.0.into(), 1.0.into());
+        let case_1_scale            = 90.0_f32.to_radians();
+        let case_1_value            = case_1_pseudo_bool * (case_1_value_normalised * case_1_scale + &default_rotation);
 
-        // Case 2
-        let case_2            = in_range_inclusive(position, &middle_segment_start_point, &middle_segment_end_point);
-        let case_2_value_base = &base_rotation;
-        let case_2_value      = case_2 * case_2_value_base;
+        let case_2_pseudo_bool = in_range_inclusive(position, &middle_segment_start_point, &middle_segment_end_point);
+        let case_2_value_base  = &default_rotation;
+        let case_2_value       = case_2_pseudo_bool * case_2_value_base;
 
         // Case 3
-        let case_3            = in_range_inclusive(position, &middle_segment_end_point, &end);
-        let case_3_value_base = ((position - middle_segment_end_point) / corner_segment_length).clamp(0.0.into(), 1.0.into());
-        let case_3_scale      = -90.0_f32.to_radians();
-        let case_3_value      = case_3 * (case_3_value_base * case_3_scale + &base_rotation);
+        let case_3_pseudo_bool      = in_range_inclusive(position, &middle_segment_end_point, &end);
+        let case_3_value_normalised = ((position - middle_segment_end_point) / corner_segment_length).clamp(0.0.into(), 1.0.into());
+        let case_3_scale            = (-90.0_f32).to_radians();
+        let case_3_value            = case_3_pseudo_bool * (case_3_value_normalised * case_3_scale + &default_rotation);
 
-        (case_1_value + case_2_value + case_3_value).into()
+        case_1_value + case_2_value + case_3_value
     }
 
     /// Returns a value between 0 and 1 that indicates the position along the straight center segment.
     fn calculate_crop_plane_position_relative_to_center_segment(full_shape_border_length:&Var<f32>, corner_segment_length:&Var<f32>, position:&Var<f32>) -> Var<f32> {
-        // let start                      = 0.0.into();
+        // TODO implement proper abstraction for non-branching "if/then/else" or "case" in shaderland
+        // See function above for explanation of the branching.
+
         let middle_segment_start_point = corner_segment_length;
         let middle_segment_end_point   = full_shape_border_length - corner_segment_length;
         let end                        = full_shape_border_length;
 
-        let one  = Var::<f32>::from(1.0);
-
         // Case 1: always zero can be ignored
 
-        // Case 2
-        let case_2            = in_range_inclusive(position, &middle_segment_start_point, &middle_segment_end_point);
-        let case_2_value_base = (position - middle_segment_start_point) / (&middle_segment_end_point - middle_segment_start_point);
-        let case_2_value      = case_2 * case_2_value_base;
+        let case_2_pseudo_bool      = in_range_inclusive(position, &middle_segment_start_point, &middle_segment_end_point);
+        let case_2_value_normalised = (position - middle_segment_start_point) / (&middle_segment_end_point - middle_segment_start_point);
+        let case_2_value            = case_2_pseudo_bool * case_2_value_normalised;
 
-        // Case 3: always 1.0
-        let case_3            = in_range_inclusive(position, &middle_segment_end_point, &end);
-        let case_3_value      = case_3 * one;
+        let case_3_pseudo_bool = in_range_inclusive(position, &middle_segment_end_point, &end);
+        let case_3_value       = case_3_pseudo_bool * 1.0;
 
-        (case_2_value + case_3_value).into()
+        case_2_value + case_3_value
 
     }
 
+    /// Compute the plane at the location of the given port index.
     fn compute_crop_plane(index:&Var<f32>, port_num: &Var<f32>, width: &Var<f32>, corner_radius:&Var<f32>, position_offset:&Var<f32>) -> AnyShape {
         let corner_circumference     = corner_radius * 2.0 * PI;
         let corner_segment_length    = &corner_circumference * 0.25;
@@ -114,15 +141,15 @@ pub mod port_area {
         let full_shape_border_length = &center_segment_length + &corner_segment_length * 2.0;
 
 
-        let position_relative    = (index / port_num);
-        let crop_segment_pos = &position_relative * &full_shape_border_length + position_offset;
+        let position_relative = index / port_num;
+        let crop_segment_pos  = &position_relative * &full_shape_border_length + position_offset;
 
         let crop_plane_pos_relative = calculate_crop_plane_position_relative_to_center_segment(&full_shape_border_length, &corner_segment_length, &crop_segment_pos);
         let crop_plane_pos          = crop_plane_pos_relative * &center_segment_length + corner_radius;
 
-        let plane_rotation_angle  = compute_crop_plane_angle(&full_shape_border_length, &corner_segment_length, &crop_segment_pos);
-        let plane_shape_offset     = Var::<Distance<Pixels>>::from(&crop_plane_pos - width * 0.5);
-        let crop_shape       = HalfPlane().rotate(plane_rotation_angle).translate_x(plane_shape_offset);
+        let plane_rotation_angle = compute_crop_plane_angle(&full_shape_border_length, &corner_segment_length, &crop_segment_pos);
+        let plane_shape_offset   = Var::<Distance<Pixels>>::from(&crop_plane_pos - width * 0.5);
+        let crop_shape           = HalfPlane().rotate(plane_rotation_angle).translate_x(plane_shape_offset);
         crop_shape.into()
     }
 
@@ -187,16 +214,215 @@ pub mod port_area {
             (port_area + hover_area).into()
         }
     }
+
+    impl PortShapeApi for Shape {
+        fn set_grow(&self, grow_value: f32) {
+            self.grow.set(grow_value)
+        }
+
+        fn set_opacity(&self, opacity: f32) {
+            self.opacity.set(opacity)
+        }
+    }
 }
 
+/// Implements an simplified version of the multi_port_area::Shape shape for the case where there is
+/// only a single output port.
+pub mod single_port_area {
+    use super::*;
+    use ensogl::display::shape::*;
 
+    ensogl::define_shape_system! {
+        (style:Style, grow:f32, opacity:f32) {
+            let overall_width  : Var<Distance<Pixels>> = "input_size.x".into();
+            let overall_height : Var<Distance<Pixels>> = "input_size.y".into();
+            let width  = &overall_width  - node::NODE_SHAPE_PADDING.px() * 2.0;
+            let height = &overall_height - node::NODE_SHAPE_PADDING.px() * 2.0;
+
+            let hover_area_size   = 20.0.px();
+            let hover_area_width  = &width  + &hover_area_size * 2.0;
+            let hover_area_height = &height / 2.0 + &hover_area_size;
+            let hover_area        = Rect((&hover_area_width,&hover_area_height));
+            let hover_area        = hover_area.translate_y(-hover_area_height/2.0);
+
+            let shrink           = 1.px() - 1.px() * &grow;
+            let radius           = 14.px();
+            let port_area_size   = 4.0.px() * &grow;
+            let port_area_width  = &width  + (&port_area_size - &shrink) * 2.0;
+            let port_area_height = &height + (&port_area_size - &shrink) * 2.0;
+            let bottom_radius    = &radius + &port_area_size;
+            let port_area        = Rect((&port_area_width,&port_area_height));
+            let port_area        = port_area.corners_radius(&bottom_radius);
+            let port_area        = port_area - BottomHalfPlane();
+            let corner_radius    = &port_area_size / 2.0;
+            let corner_offset    = &port_area_width / 2.0 - &corner_radius;
+            let corner           = Circle(&corner_radius);
+            let left_corner      = corner.translate_x(-&corner_offset);
+            let right_corner     = corner.translate_x(&corner_offset);
+            let port_area        = port_area + left_corner + right_corner;
+            let port_area        = port_area.fill(color::Rgba::from(color::Lcha::new(0.6,0.5,0.76,1.0)));
+
+            // FIXME: Use colour from style and apply transparency there.
+            let color     = Var::<color::Rgba>::from("srgba(0.25,0.58,0.91,input_opacity)");
+            let port_area = port_area.fill(color);
+
+            (port_area + hover_area).into()
+        }
+    }
+
+    impl PortShapeApi for Shape {
+        fn set_grow(&self, grow_value: f32) {
+            self.grow.set(grow_value)
+        }
+
+        fn set_opacity(&self, opacity: f32) {
+            self.opacity.set(opacity)
+        }
+    }
+}
+
+/// Helper enum that handles the distinction between a single shape output area and a multi port
+/// output area.
+#[derive(Clone,Debug)]
+enum ShapeView {
+    Single { view  : component::ShapeView<multi_port_area::Shape>      },
+    Multi  { views : Vec<component::ShapeView<multi_port_area::Shape>> },
+}
+
+impl ShapeView {
+
+    /// Constructor.
+    fn new(number_of_ports:u32, logger:&Logger, scene:&Scene) -> Self {
+        if number_of_ports == 1 {
+            ShapeView::Single { view: component::ShapeView::new(&logger,&scene) }
+        } else {
+            let mut views = Vec::default();
+            views.resize_with(number_of_ports as usize,|| component::ShapeView::new(&logger,&scene));
+            ShapeView::Multi { views }
+        }
+    }
+
+    /// Set up the frp for all ports.
+    fn init_frp(&self, port_frp:PortFrp) {
+        match self {
+            ShapeView::Single {view}  => init_port_frp(&view, PortId{index:0},port_frp),
+            ShapeView::Multi  {views} => {
+                views.iter().enumerate().for_each(|(index,view)| {
+                    init_port_frp(&view, PortId{index},port_frp.clone_ref())
+                } )
+            }
+        }
+    }
+
+    /// Resize all the port output shapes to fit the new layout requirements for thr given
+    /// parameters.
+    fn update_shape_layout_based_on_size_and_gap(&self, size:Vector2<f32>, gap_width:f32) {
+        match self {
+            ShapeView::Single { view }   => {
+                let shape = &view.shape;
+                shape.sprite.size.set(size);
+            }
+            ShapeView::Multi { views }   => {
+                let port_num  = views.len() as f32;
+                // Align shapes along width.
+                for (index, view) in views.iter().enumerate(){
+                    let shape = &view.shape;
+                    shape.sprite.size.set(size);
+                    shape.index.set(index as f32);
+                    shape.port_num.set(port_num);
+                    shape.padding.set(gap_width);
+                }
+            }
+        }
+    }
+
+    fn set_parent<T:display::object::Object>(&self, parent:&T) {
+        match self {
+            ShapeView::Single { view }   => {
+                view.display_object().set_parent(parent);
+            }
+            ShapeView::Multi { views }   => {
+                views.iter().for_each(|view|  view.display_object().set_parent(parent))
+            }
+        }
+    }
+}
+
+// =============================
+// === Port Frp Setup Helper ===
+// =============================
+
+/// Helper struct to pass the required FRP endpoints to set up the FRP of a port shape view.
+#[derive(Clone,CloneRef,Debug)]
+struct PortFrp {
+    network                      : frp::Network,
+
+    port_mouse_over              : frp::Source<PortId>,
+    port_mouse_out               : frp::Source<PortId>,
+    port_mouse_down              : frp::Source<PortId>,
+
+    hide_all                     : frp::Stream<()>,
+    activate_ports_with_selected : frp::Stream<PortId>
+}
+
+/// Set up the FRP system for a ShapeView of a shape that implements the PortShapeApi.
+///
+/// This allows us to use the same setup code for bot the `multi_port_area::Shape` and the
+/// `single_port_area::Shape`.
+fn init_port_frp<Shape:PortShapeApi+CloneRef+'static>
+(view:&component::ShapeView<Shape>, port_id:PortId,frp:PortFrp) {
+    let PortFrp { network, port_mouse_over, port_mouse_out, port_mouse_down,
+        hide_all, activate_ports_with_selected } = frp;
+
+    let shape        = &view.shape;
+    let port_size    = Animation::<f32>::new(&network);
+    let port_opacity = Animation::<f32>::new(&network);
+
+    frp::extend! { network
+
+            // === Mouse Event Handling == ///
+
+            eval_ view.events.mouse_over(port_mouse_over.emit(port_id));
+            eval_ view.events.mouse_out(port_mouse_out.emit(port_id));
+            eval_ view.events.mouse_down(port_mouse_down.emit(port_id));
+
+
+             // === Animation Handling == ///
+
+             eval port_size.value    ((size) shape.set_grow(*size));
+             eval port_opacity.value ((size) shape.set_opacity(*size));
+
+
+            // === Visibility and Highlight Handling == ///
+
+             def _hide_all = hide_all.map(f_!([port_size,port_opacity]{
+                 port_size.set_target_value(0.0);
+                 port_opacity.set_target_value(0.0);
+             }));
+
+            // Through the provided ID we can infer whether this port should be highlighted.
+            is_selected      <- activate_ports_with_selected.map(move |id| *id == port_id);
+            show_normal      <- activate_ports_with_selected.gate_not(&is_selected);
+            show_highlighted <- activate_ports_with_selected.gate(&is_selected);
+
+            eval_ show_highlighted ([port_opacity,port_size]{
+                port_opacity.set_target_value(1.0);
+                port_size.set_target_value(HIGHLIGHT_SIZE);
+            });
+
+            eval_ show_normal ([port_opacity,port_size]
+                port_opacity.set_target_value(0.5);
+                port_size.set_target_value(BASE_SIZE);
+            );
+        }
+}
 
 // ===========
 // === Frp ===
 // ===========
 
 /// Id of a specific port inside of `OutPutPortsData`.
-#[derive(Clone,Copy,Default,Debug)]
+#[derive(Clone,Copy,Default,Debug,Eq,PartialEq)]
 pub struct PortId {
     index: usize,
 }
@@ -237,7 +463,7 @@ pub struct OutputPortsData {
     logger         : Logger,
     size           : Cell<Vector2<f32>>,
     gap_width      : Cell<f32>,
-    ports          : RefCell<Vec<component::ShapeView<port_area::Shape>>>,
+    ports          : RefCell<ShapeView>,
 }
 
 impl OutputPortsData {
@@ -247,16 +473,15 @@ impl OutputPortsData {
         let display_object = display::object::Instance::new(&logger);
         let size           = Cell::new(Vector2::zero());
         let gap_width      = Cell::new(SEGMENT_GAP_WIDTH);
-
-        let mut ports      = Vec::default();
-        ports.resize_with(number_of_ports as usize,|| component::ShapeView::new(&logger,&scene));
+        let ports          = ShapeView::new(number_of_ports, &logger, &scene);
         let ports          = RefCell::new(ports);
 
         OutputPortsData {display_object,logger,size,ports,gap_width}.init()
     }
 
     fn init(self) -> Self {
-        self.update_shape_layout_based_on_size();
+        self.ports.borrow().set_parent(&self.display_object);
+        self.update_shape_layout_based_on_size_and_gap();
         self
     }
 
@@ -289,7 +514,7 @@ impl OutputPortsData {
 
     fn set_size(&self, size:Vector2<f32>) {
         self.size.set(size);
-        self.update_shape_layout_based_on_size();
+        self.update_shape_layout_based_on_size_and_gap();
     }
 }
 
@@ -391,51 +616,12 @@ impl OutputPorts {
 
         }
 
-        // Init ports
-        for (index,view) in data.ports.borrow().iter().enumerate() {
-            let shape        = &view.shape;
-            let port_size    = Animation::<f32>::new(&network);
-            let port_opacity = Animation::<f32>::new(&network);
+        let port_frp = PortFrp {network         : network.clone_ref(),
+                                port_mouse_down : frp.on_port_mouse_down.clone_ref(),
+                                port_mouse_over,port_mouse_out,hide_all,
+                                activate_ports_with_selected};
 
-            frp::extend! { network
-
-
-                // === Mouse Event Handling == ///
-
-                eval_ view.events.mouse_over(port_mouse_over.emit(PortId{index}));
-                eval_ view.events.mouse_out(port_mouse_out.emit(PortId{index}));
-                eval_ view.events.mouse_down(frp.on_port_mouse_down.emit(PortId{index}));
-
-
-                 // === Animation Handling == ///
-
-                 eval port_size.value    ((size) shape.grow.set(*size));
-                 eval port_opacity.value ((size) shape.opacity.set(*size));
-
-
-                // === Visibility and Highlight Handling == ///
-
-                 def _hide_all = hide_all.map(f_!([port_size,port_opacity]{
-                     port_size.set_target_value(0.0);
-                     port_opacity.set_target_value(0.0);
-                 }));
-
-                // Through the provided ID we can infer whether this port should be highlighted.
-                is_selected      <- activate_ports_with_selected.map(move |id| id.index == index);
-                show_normal      <- activate_ports_with_selected.gate_not(&is_selected);
-                show_highlighted <- activate_ports_with_selected.gate(&is_selected);
-
-                eval_ show_highlighted ([port_opacity,port_size]{
-                    port_opacity.set_target_value(1.0);
-                    port_size.set_target_value(HIGHLIGHT_SIZE);
-                });
-
-                eval_ show_normal ([port_opacity,port_size]
-                    port_opacity.set_target_value(0.5);
-                    port_size.set_target_value(BASE_SIZE);
-                );
-            }
-        }
+        data.ports.borrow().init_frp(port_frp);
 
         // FIXME this is a hack to ensure the ports are invisible at startup.
         // Right now we get some of FRP mouse events on startup that leave the
@@ -448,7 +634,7 @@ impl OutputPorts {
     /// Hack function used to register the elements for the sorting purposes. To be removed.
     pub(crate) fn order_hack(scene:&Scene) {
         let logger = Logger::new("hack");
-        component::ShapeView::<port_area::Shape>::new(&logger,scene);
+        component::ShapeView::<multi_port_area::Shape>::new(&logger, scene);
     }
 }
 

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -136,7 +136,7 @@ pub struct OutPutPortsData {
 
 impl OutPutPortsData {
 
-    fn new(scene:Scene, number_of_ports:u8) -> Self {
+    fn new(scene:Scene, number_of_ports:u32) -> Self {
         let logger         = Logger::new("OutPutPorts");
         let display_object = display::object::Instance::new(&logger);
         let size           = Cell::new(Vector2::zero());
@@ -205,7 +205,7 @@ pub struct OutputPorts {
 }
 
 impl OutputPorts {
-    pub fn new(scene:&Scene, number_of_ports:u8) -> Self {
+    pub fn new(scene:&Scene, number_of_ports:u32) -> Self {
 
         let network        = default();
         let frp            = Frp::new(&network);

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -163,17 +163,17 @@ impl OutPutPortsData {
     }
 
     fn update_shape_layout_based_on_size(&self) {
-        let port_num      = self.ports.borrow().len() as f32;
+        let port_num    = self.ports.borrow().len() as f32;
 
-        let width         = self.size.get().x;
-        let height        = self.size.get().y;
-        let element_width = (width - NODE_SHAPE_PADDING) / port_num;
-        let element_size  = Vector2::new(element_width,height);
-        let gap_width     = self.gap_width.get();
+        let width       = self.size.get().x;
+        let height      = self.size.get().y;
+        let port_width  = (width - NODE_SHAPE_PADDING) / port_num;
+        let port_size   = Vector2::new(port_width, height);
+        let gap_width   = self.gap_width.get();
 
         // Align shapes along width.
         let x_start = -width / 2.0 + NODE_SHAPE_PADDING;
-        let x_delta = element_width;
+        let x_delta = port_width;
         for (index, view) in self.ports.borrow().iter().enumerate(){
             view.display_object().set_parent(&self.display_object);
 
@@ -183,7 +183,7 @@ impl OutPutPortsData {
             view.set_position_xy(pos);
 
             let shape = &view.shape;
-            shape.sprite.size().set(element_size);
+            shape.sprite.size().set(port_size);
             shape.shape_width.set(width);
             shape.padding.set(gap_width);
             shape.offset_x.set(x_delta * index as f32);

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -237,7 +237,8 @@ pub mod multi_port_area {
     }
 
     ensogl::define_shape_system! {
-        (style:Style, grow:f32, index:f32, port_num:f32, padding:f32, opacity:f32) {
+        (style:Style, grow:f32, index:f32, port_num:f32, opacity:f32, padding_left:f32,
+        padding_right:f32) {
             let overall_width  : Var<Distance<Pixels>> = "input_size.x".into();
             let overall_height : Var<Distance<Pixels>> = "input_size.y".into();
 
@@ -248,12 +249,12 @@ pub mod multi_port_area {
                                                       &port_num,
                                                       &width.clone().into(),
                                                       &radius.clone().into(),
-                                                      &(&padding * 0.5));
+                                                      &padding_left);
             let right_shape_crop = compute_crop_plane(&(Var::<f32>::from(1.0) + &index),
                                                       &port_num,
                                                       &width.clone().into(),
                                                       &radius.clone().into(),
-                                                      &(-&padding * 0.5));
+                                                      &padding_right);
 
             let port_area  = port_area.difference(&left_shape_crop);
             let port_area  = port_area.intersection(&right_shape_crop);
@@ -368,8 +369,11 @@ impl ShapeView {
                     shape.sprite.size.set(size);
                     shape.index.set(index as f32);
                     shape.port_num.set(port_num);
-                    shape.padding.set(gap_width);
+                    shape.padding_left.set(gap_width * 0.5);
+                    shape.padding_right.set(-gap_width * 0.5);
                 }
+                views[0]              .shape.padding_left .set(0.0);
+                views[views.len() - 1].shape.padding_right.set(0.0);
             }
         }
     }

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -474,10 +474,10 @@ fn init_port_frp<Shape: PortShape +CloneRef+'static>
 
         // === Visibility and Highlight Handling == ///
 
-         def _hide_all = hide_all.map(f_!([port_size,port_opacity]{
+         eval_ hide_all ([port_size,port_opacity]{
              port_size.set_target_value(0.0);
              port_opacity.set_target_value(0.0);
-         }));
+         });
 
         // Through the provided ID we can infer whether this port should be highlighted.
         is_selected      <- activate_and_highlight_selected.map(move |id| *id == port_id);
@@ -489,10 +489,10 @@ fn init_port_frp<Shape: PortShape +CloneRef+'static>
             port_size.set_target_value(HIGHLIGHT_SIZE);
         });
 
-        eval_ show_normal ([port_opacity,port_size]
+        eval_ show_normal ([port_opacity,port_size] {
             port_opacity.set_target_value(0.5);
             port_size.set_target_value(BASE_SIZE);
-        );
+        });
     }
 }
 

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -133,7 +133,7 @@ pub mod multi_port_area {
     fn in_range_inclusive
     (value:&Var<f32>, lower_bound:&Var<f32>, upper_bound:&Var<f32>) -> Var<f32> {
         Var::<f32>::from(format!("(step(float({1}),float({0})) * step(float({0}),float({2})))",
-                                 value, lower_bound, upper_bound))
+                                 value, ower_bound,upper_bound))
     }
 
     /// Compute the angle perpendicular to the shape border.
@@ -161,10 +161,10 @@ pub mod multi_port_area {
 
         // Case 2: The right circle segment.
         let is_corner_circle_case = in_range_inclusive
-            (&center_distance_absolute, &center_segment_end, &end);
+            (&center_distance_absolute,&center_segment_end,&end);
         let relative_position     = (center_distance_absolute - center_segment_end)
                                     / corner_segment_length;
-        let relative_position     = relative_position.clamp(0.0.into(), 1.0.into());
+        let relative_position     = relative_position.clamp(0.0.into(),1.0.into());
         let corner_base_rotation  = (-90.0_f32).to_radians();
         let corner_rotation_delta = relative_position * corner_base_rotation;
         let rotation_delta        = is_corner_circle_case * corner_rotation_delta;
@@ -195,14 +195,14 @@ pub mod multi_port_area {
 
         // Case 2: The middle segment.
         let is_middle_segment               = in_range_inclusive
-            (position_on_path, &middle_segment_start_point, &middle_segment_end_point);
+            (position_on_path,&middle_segment_start_point,&middle_segment_end_point);
         let middle_segment_plane_position_x = (position_on_path - middle_segment_start_point)
             / (&middle_segment_end_point - middle_segment_start_point);
         let case_middle_segment_output      = is_middle_segment * middle_segment_plane_position_x;
 
         // Case 3: The right circle segment. Always one, if we are in this segment.
         let is_circle_segment          = in_range_inclusive
-            (position_on_path, &middle_segment_end_point, &full_shape_border_length);
+            (position_on_path,&middle_segment_end_point,&full_shape_border_length);
         let case_circle_segment_output = is_circle_segment * 1.0;
 
         case_middle_segment_output + case_circle_segment_output
@@ -245,7 +245,7 @@ pub mod multi_port_area {
             let overall_width  : Var<Distance<Pixels>> = "input_size.x".into();
             let overall_height : Var<Distance<Pixels>> = "input_size.y".into();
 
-            let base_shape_data = BaseShapeData::new(&overall_width, &overall_height, &grow);
+            let base_shape_data = BaseShapeData::new(&overall_width,&overall_height,&grow);
             let BaseShapeData{ port_area,hover_area,radius,width } = base_shape_data;
 
             let left_shape_crop  = compute_crop_plane
@@ -353,7 +353,7 @@ impl ShapeView {
             let number_of_ports = number_of_ports as usize;
             views.resize_with(number_of_ports,|| component::ShapeView::new(&logger,&scene));
             views.iter().for_each(|view|  view.display_object().set_parent(&display_object));
-            ShapeView::Multi { display_object, views }
+            ShapeView::Multi {display_object,views}
         }
     }
 
@@ -363,7 +363,7 @@ impl ShapeView {
             ShapeView::Single {view}  => init_port_frp(&view,PortId::new(0),port_frp,network),
             ShapeView::Multi  {views, ..} => {
                 views.iter().enumerate().for_each(|(index,view)| {
-                    init_port_frp(&view, PortId::new(index),port_frp.clone_ref(),network)
+                    init_port_frp(&view,PortId::new(index),port_frp.clone_ref(),network)
                 })
             }
         }
@@ -379,7 +379,7 @@ impl ShapeView {
             }
             ShapeView::Multi { views, .. } => {
                 let port_num  = views.len() as f32;
-                for (index, view) in views.iter().enumerate(){
+                for (index,view) in views.iter().enumerate(){
                     let shape = &view.shape;
                     shape.sprite.size.set(size);
                     shape.index.set(index as f32);
@@ -446,7 +446,7 @@ struct PortFrp {
 fn init_port_frp<Shape: PortShape +CloneRef+'static>
 (view:&component::ShapeView<Shape>, port_id:PortId, frp:PortFrp, network:&frp::Network) {
     let PortFrp { mouse_over,mouse_out,mouse_down,
-        hide_all, activate_and_highlight_selected} = frp;
+        hide_all,activate_and_highlight_selected} = frp;
 
     let shape        = &view.shape;
     let port_size    = Animation::<f32>::new(&network);
@@ -545,7 +545,7 @@ impl OutputPortsData {
         let display_object = display::object::Instance::new(&logger);
         let size           = Cell::new(Vector2::zero());
         let gap_width      = Cell::new(SEGMENT_GAP_WIDTH);
-        let ports          = ShapeView::new(number_of_ports, &logger, scene);
+        let ports          = ShapeView::new(number_of_ports,&logger,scene);
         let ports          = RefCell::new(ports);
 
         OutputPortsData {display_object,logger,size,ports,gap_width}.init()
@@ -598,7 +598,7 @@ impl OutputPorts {
     pub fn new(scene:&Scene, number_of_ports:NonZeroU32) -> Self {
         let network = default();
         let frp     = Frp::new(&network);
-        let data    = OutputPortsData::new(scene, number_of_ports);
+        let data    = OutputPortsData::new(scene,number_of_ports);
         let data    = Rc::new(data);
         OutputPorts {data,network,frp}.init()
     }
@@ -668,7 +668,7 @@ impl OutputPorts {
             activate_and_highlight_selected
         };
 
-        data.ports.borrow().init_frp(&network, port_frp);
+        data.ports.borrow().init_frp(&network,port_frp);
 
         // // FIXME this is a hack to ensure the ports are invisible at startup.
         // // Right now we get some of FRP mouse events on startup that leave the
@@ -683,7 +683,7 @@ impl OutputPorts {
     /// Hack function used to register the elements for the sorting purposes. To be removed.
     pub(crate) fn order_hack(scene:&Scene) {
         let logger = Logger::new("output shape order hack");
-        component::ShapeView::<multi_port_area::Shape>::new(&logger, scene);
+        component::ShapeView::<multi_port_area::Shape>::new(&logger,scene);
     }
 }
 

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -248,19 +248,20 @@ pub mod multi_port_area {
             let base_shape_data = BaseShapeData::new(&overall_width,&overall_height,&grow);
             let BaseShapeData{ port_area,hover_area,radius,width } = base_shape_data;
 
+            let radius:Var::<f32> = radius.into();
+            let width:Var::<f32>  = width.into();
+
             let left_shape_crop  = compute_crop_plane
-                (&index,&port_num,&width.clone().into(),&radius.clone().into(),&padding_left);
-            let right_shape_crop = compute_crop_plane(
-                &(Var::<f32>::from(1.0) + &index),&port_num,&width.clone().into(),
-                &radius.clone().into(),&padding_right);
+                (&index,&port_num,&width,&radius,&padding_left);
+            let right_shape_crop = compute_crop_plane
+                (&(Var::<f32>::from(1.0) + &index),&port_num,&width,&radius,&padding_right);
 
             let port_area  = port_area.difference(&left_shape_crop);
             let port_area  = port_area.intersection(&right_shape_crop);
 
-            let left_hover_crop  = compute_crop_plane(&index,&port_num,&width.clone().into(),
-                                                      &radius.clone().into(),&0.0.into());
-            let right_hover_crop = compute_crop_plane(&(Var::<f32>::from(1.0) + &index),&port_num,
-                                                      &width.into(),&radius.into(),&0.0.into());
+            let left_hover_crop  = compute_crop_plane(&index,&port_num,&width,&radius,&0.0.into());
+            let right_hover_crop = compute_crop_plane
+                (&(Var::<f32>::from(1.0) + &index),&port_num,&width,&radius,&0.0.into());
 
             let hover_area = hover_area.difference(&left_hover_crop);
             let hover_area = hover_area.intersection(&right_hover_crop);

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -545,12 +545,12 @@ pub struct OutputPortsData {
 
 impl OutputPortsData {
 
-    fn new(scene:Scene, number_of_ports:NonZeroU32) -> Self {
+    fn new(scene:&Scene, number_of_ports:NonZeroU32) -> Self {
         let logger         = Logger::new("OutputPorts");
         let display_object = display::object::Instance::new(&logger);
         let size           = Cell::new(Vector2::zero());
         let gap_width      = Cell::new(SEGMENT_GAP_WIDTH);
-        let ports          = ShapeView::new(number_of_ports, &logger, &scene);
+        let ports          = ShapeView::new(number_of_ports, &logger, scene);
         let ports          = RefCell::new(ports);
 
         OutputPortsData {display_object,logger,size,ports,gap_width}.init()
@@ -603,7 +603,7 @@ impl OutputPorts {
     pub fn new(scene:&Scene, number_of_ports:NonZeroU32) -> Self {
         let network = default();
         let frp     = Frp::new(&network);
-        let data    = OutputPortsData::new(scene.clone_ref(), number_of_ports);
+        let data    = OutputPortsData::new(scene, number_of_ports);
         let data    = Rc::new(data);
         OutputPorts {data,network,frp}.init()
     }

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -1,6 +1,8 @@
 //! Implements the segmented output port area.
 use crate::prelude::*;
 
+use ensogl::display::traits::*;
+
 use enso_frp as frp;
 use enso_frp;
 use ensogl::data::color;
@@ -8,15 +10,11 @@ use ensogl::display::Attribute;
 use ensogl::display::Buffer;
 use ensogl::display::Sprite;
 use ensogl::display::scene::Scene;
-use ensogl::display::shape::*;
-use ensogl::display::traits::*;
 use ensogl::display;
 use ensogl::gui::component::Animation;
 use ensogl::gui::component;
 
-use crate::node::NODE_SHAPE_PADDING;
-use crate::node::NODE_SHAPE_RADIUS;
-
+use crate::node;
 
 
 // =================
@@ -38,13 +36,14 @@ const SEGMENT_GAP_WIDTH   : f32 = 2.0;
 /// each segment. Each shapes represents a window of the underlying shape.
 pub mod port_area {
     use super::*;
+    use ensogl::display::shape::*;
 
     ensogl::define_shape_system! {
         (style:Style, grow:f32, shape_width:f32, offset_x:f32, padding:f32, opacity:f32) {
             let width  : Var<Distance<Pixels>> = shape_width.into();
             let height : Var<Distance<Pixels>> = "input_size.y".into();
-            let width  = width  - NODE_SHAPE_PADDING.px() * 2.0;
-            let height = height - NODE_SHAPE_PADDING.px() * 2.0;
+            let width  = width  - node::NODE_SHAPE_PADDING.px() * 2.0;
+            let height = height - node::NODE_SHAPE_PADDING.px() * 2.0;
 
             let hover_area_size   = 20.0.px();
             let hover_area_width  = &width  + &hover_area_size * 2.0;
@@ -54,7 +53,7 @@ pub mod port_area {
             let hover_area        = hover_area.fill(color::Rgba::new(0.0,0.0,0.0,0.000_001));
 
             let shrink           = 1.px() - 1.px() * &grow;
-            let radius           = NODE_SHAPE_RADIUS.px();
+            let radius           = node::NODE_SHAPE_RADIUS.px();
             let port_area_size   = 4.0.px() * &grow;
             let port_area_width  = &width  + (&port_area_size - &shrink) * 2.0;
             let port_area_height = &height + (&port_area_size - &shrink) * 2.0;
@@ -162,12 +161,12 @@ impl OutPutPortsData {
         let port_num    = self.ports.borrow().len() as f32;
         let width       = self.size.get().x;
         let height      = self.size.get().y;
-        let port_width  = (width - NODE_SHAPE_PADDING) / port_num;
+        let port_width  = (width - node::NODE_SHAPE_PADDING) / port_num;
         let port_size   = Vector2::new(port_width, height);
         let gap_width   = self.gap_width.get();
 
         // Align shapes along width.
-        let x_start = -width / 2.0 + NODE_SHAPE_PADDING;
+        let x_start = -width / 2.0 + node::NODE_SHAPE_PADDING;
         let x_delta = port_width;
         for (index, view) in self.ports.borrow().iter().enumerate(){
             view.display_object().set_parent(&self.display_object);

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -130,7 +130,7 @@ impl Frp {
 
 /// Internal data of the `OutPutPorts`.
 #[derive(Debug)]
-pub struct OutPutPortsData {
+pub struct OutputPortsData {
     display_object : display::object::Instance,
     logger         : Logger,
     size           : Cell<Vector2<f32>>,
@@ -138,7 +138,7 @@ pub struct OutPutPortsData {
     ports          : RefCell<Vec<component::ShapeView<port_area::Shape>>>,
 }
 
-impl OutPutPortsData {
+impl OutputPortsData {
 
     fn new(scene:Scene, number_of_ports:u32) -> Self {
         let logger         = Logger::new("OutPutPorts");
@@ -150,20 +150,21 @@ impl OutPutPortsData {
         ports.resize_with(number_of_ports as usize,|| component::ShapeView::new(&logger,&scene));
         let ports          = RefCell::new(ports);
 
-        OutPutPortsData {display_object,logger,size,ports,gap_width}.init()
+        OutputPortsData {display_object,logger,size,ports,gap_width}.init()
     }
+
     fn init(self) -> Self {
         self.update_shape_layout_based_on_size();
         self
     }
 
     fn update_shape_layout_based_on_size(&self) {
-        let port_num    = self.ports.borrow().len() as f32;
-        let width       = self.size.get().x;
-        let height      = self.size.get().y;
-        let port_width  = (width - node::NODE_SHAPE_PADDING) / port_num;
-        let port_size   = Vector2::new(port_width, height);
-        let gap_width   = self.gap_width.get();
+        let port_num   = self.ports.borrow().len() as f32;
+        let width      = self.size.get().x;
+        let height     = self.size.get().y;
+        let port_width = (width - node::NODE_SHAPE_PADDING) / port_num;
+        let port_size  = Vector2::new(port_width, height);
+        let gap_width  = self.gap_width.get();
 
         // Align shapes along width.
         let x_start = -width / 2.0 + node::NODE_SHAPE_PADDING;
@@ -209,20 +210,18 @@ impl OutPutPortsData {
 #[derive(Debug,Clone,CloneRef)]
 pub struct OutputPorts {
     /// The FRP api of the `OutPutPorts`.
-    pub frp            : Frp,
-        network        : frp::Network,
-        data           : Rc<OutPutPortsData>,
+    pub frp     : Frp,
+        network : frp::Network,
+        data    : Rc<OutputPortsData>,
 }
 
 impl OutputPorts {
     /// Constructor.
     pub fn new(scene:&Scene, number_of_ports:u32) -> Self {
-
-        let network        = default();
-        let frp            = Frp::new(&network);
-        let data           = OutPutPortsData::new(scene.clone_ref(),number_of_ports);
-        let data           = Rc::new(data);
-
+        let network = default();
+        let frp     = Frp::new(&network);
+        let data    = OutputPortsData::new(scene.clone_ref(), number_of_ports);
+        let data    = Rc::new(data);
         OutputPorts {data,network,frp}.init()
     }
 

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -257,32 +257,26 @@ impl OutputPorts {
 
                     is_resize_target <- set_port_size.map(move |(id,_)| *id == index);
                     size_change      <- set_port_size.gate(&is_resize_target);
-                    _change_size     <- size_change.map(f!(((_, size))  {
-                        port_size.set_target_value(*size)
-                    }));
+                    eval size_change (((_, size)) port_size.set_target_value(*size));
 
                     is_opacity_target <- set_port_opacity.map(move |(id, _)| *id==index);
                     opacity_change    <- set_port_opacity.gate(&is_opacity_target);
-                    _change_size      <- opacity_change.map(f!(((_, opacity))  {
-                        port_opacity.set_target_value(*opacity)
-                    }));
+                    eval opacity_change (((_, opacity)) port_opacity.set_target_value(*opacity));
 
-                    eval view.events.mouse_over ([port_size,set_port_sizes_all,port_opacity,
-                                                  set_port_opacity_all](_) {
+                    eval_ view.events.mouse_over ([port_size,set_port_sizes_all,port_opacity,
+                                                  set_port_opacity_all] {
                         set_port_sizes_all.emit(BASE_SIZE);
                         set_port_opacity_all.emit(0.5);
                         port_size.set_target_value(HIGHLIGHT_SIZE);
                         port_opacity.set_target_value(1.0);
                     });
 
-                    eval view.events.mouse_out ([set_port_sizes_all,set_port_opacity_all](_) {
+                    eval_ view.events.mouse_out ([set_port_sizes_all,set_port_opacity_all] {
                          set_port_sizes_all.emit(0.0);
                          set_port_opacity_all.emit(0.0);
                     });
 
-                    eval view.events.mouse_down ([frp](_) {
-                        frp.on_port_mouse_down.emit(index);
-                    });
+                    eval_ view.events.mouse_down(frp.on_port_mouse_down.emit(index));
                 }
             }
         }

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -418,7 +418,7 @@ fn init_port_frp<Shape:PortShapeApi+CloneRef+'static>
     let port_size    = Animation::<f32>::new(&network);
     let port_opacity = Animation::<f32>::new(&network);
 
-    frp::extend! { network
+    frp::extend! { TRACE_ALL network
 
             // === Mouse Event Handling == ///
 
@@ -603,7 +603,7 @@ impl OutputPorts {
         let delay_hide = Tween::new(&network);
         delay_hide.set_duration(HIDE_DELAY_DURATION);
 
-        frp::extend! { network
+        frp::extend! { TRACE_ALL network
 
             // === Size Change Handling == ///
 
@@ -625,12 +625,12 @@ impl OutputPorts {
             mouse_over_while_inactive  <- port_mouse_over.gate_not(&visible).constant(());
             mouse_over_while_active    <- port_mouse_over.gate(&visible).constant(());
 
-            eval mouse_over_while_inactive ([delay_show,delay_hide](_){
+            eval_ mouse_over_while_inactive ([delay_show,delay_hide]{
                 delay_hide.stop();
                 delay_show.rewind();
                 delay_show.set_end_value(TWEEN_END_VALUE);
             });
-            eval port_mouse_out ([delay_hide,delay_show](_){
+            eval_ port_mouse_out ([delay_hide,delay_show]{
                 delay_show.stop();
                 delay_hide.rewind();
                 delay_hide.set_end_value(TWEEN_END_VALUE);
@@ -652,11 +652,11 @@ impl OutputPorts {
 
         data.ports.borrow().init_frp(port_frp);
 
-        // FIXME this is a hack to ensure the ports are invisible at startup.
-        // Right now we get some of FRP mouse events on startup that leave the
-        // ports visible by default.
-        // Once that is fixed, remove this line.
-        delay_hide.finish();
+        // // FIXME this is a hack to ensure the ports are invisible at startup.
+        // // Right now we get some of FRP mouse events on startup that leave the
+        // // ports visible by default.
+        // // Once that is fixed, remove this line.
+        // delay_hide.finish();
     }
 
     // TODO: Implement proper sorting and remove.

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -251,6 +251,7 @@ pub mod multi_port_area {
             let radius:Var::<f32> = radius.into();
             let width:Var::<f32>  = width.into();
 
+            // Crop planes for the visible port area. Includes padding.
             let left_shape_crop  = compute_crop_plane
                 (&index,&port_num,&width,&radius,&padding_left);
             let right_shape_crop = compute_crop_plane
@@ -259,6 +260,7 @@ pub mod multi_port_area {
             let port_area  = port_area.difference(&left_shape_crop);
             let port_area  = port_area.intersection(&right_shape_crop);
 
+            // Crop planes for the invisible hover area. No padding.
             let left_hover_crop  = compute_crop_plane(&index,&port_num,&width,&radius,&0.0.into());
             let right_hover_crop = compute_crop_plane
                 (&(Var::<f32>::from(1.0) + &index),&port_num,&width,&radius,&0.0.into());

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -265,7 +265,7 @@ pub mod multi_port_area {
             let hover_area = hover_area.intersection(&right_hover_crop);
             let hover_area = hover_area.fill(color::Rgba::new(0.0,0.0,0.0,0.000_001));
 
-            // FIXME: Use colour from style and apply transparency there.
+            // FIXME: Use color from style and apply transparency there.
             let color     = Var::<color::Rgba>::from("srgba(0.25,0.58,0.91,input_opacity)");
             let port_area = port_area.fill(color);
 
@@ -298,7 +298,7 @@ pub mod single_port_area {
             let base_shape_data = BaseShapeData::new(&overall_width,&overall_height,&grow);
             let BaseShapeData{ port_area,hover_area, .. } = base_shape_data;
 
-            // FIXME: Use colour from style and apply transparency there.
+            // FIXME: Use color from style and apply transparency there.
             let color     = Var::<color::Rgba>::from("srgba(0.25,0.58,0.91,input_opacity)");
             let port_area = port_area.fill(color);
 

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -96,11 +96,15 @@ pub mod port_area {
 // === Frp ===
 // ===========
 
+/// Id of a specific port inside of `OutPutPortsData`.
 type PortId = usize;
 
+/// Frp API of the `OutPutPorts`.
 #[derive(Clone,CloneRef,Debug)]
 pub struct Frp {
+    /// Update the size of the `OutPutPorts`. Should match the size of the parent node for visual correctness.
     pub set_size        : frp::Source<V2<f32>>,
+    /// Emitted whenever one of the ports receives a `MouseDown` event. The `PortId` indicates the source port.
     pub port_mouse_down : frp::Stream<PortId>,
 
     on_port_mouse_down  : frp::Source<PortId>,
@@ -124,6 +128,7 @@ impl Frp {
 // === OutPutPortsData ===
 // =======================
 
+/// Internal data of the `OutPutPorts`.
 #[derive(Debug)]
 pub struct OutPutPortsData {
     display_object : display::object::Instance,
@@ -196,8 +201,12 @@ impl OutPutPortsData {
 // === OutPutPorts ===
 // ===================
 
+/// Implements the segmented output port area. Provides shapes that can be attached to a `Node` to
+/// add an interactive area with output ports. The ports appear on hover, and the currently
+/// hovered port is highlighted.
 #[derive(Debug,Clone,CloneRef)]
 pub struct OutputPorts {
+    /// The FRP api of the `OutPutPorts`.
     pub frp            : Frp,
         network        : frp::Network,
         data           : Rc<RefCell<OutPutPortsData>>,
@@ -205,6 +214,7 @@ pub struct OutputPorts {
 }
 
 impl OutputPorts {
+    /// Constructor.
     pub fn new(scene:&Scene, number_of_ports:u32) -> Self {
 
         let network        = default();
@@ -283,7 +293,6 @@ impl OutputPorts {
                 eval_ view.events.mouse_down(frp.on_port_mouse_down.emit(index));
             }
         }
-
     }
 
     // TODO: Implement proper sorting and remove.

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -344,10 +344,10 @@ impl ShapeView {
     /// Set up the frp for all ports.
     fn init_frp(&self, port_frp:PortFrp) {
         match self {
-            ShapeView::Single {view}  => init_port_frp(&view, PortId{index:0},port_frp),
+            ShapeView::Single {view}  => init_port_frp(&view, PortId::new(0),port_frp),
             ShapeView::Multi  {views} => {
                 views.iter().enumerate().for_each(|(index,view)| {
-                    init_port_frp(&view, PortId{index},port_frp.clone_ref())
+                    init_port_frp(&view, PortId::new(index),port_frp.clone_ref())
                 })
             }
         }
@@ -467,6 +467,12 @@ fn init_port_frp<Shape:PortShapeApi+CloneRef+'static>
 #[derive(Clone,Copy,Default,Debug,Eq,PartialEq)]
 pub struct PortId {
     index: usize,
+}
+
+impl PortId {
+    fn new(index:usize) -> Self {
+        Self{index}
+    }
 }
 
 /// Frp API of the `OutPutPorts`.

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -12,6 +12,7 @@ use ensogl::display::shape::*;
 use ensogl::display::traits::*;
 use ensogl::display;
 use ensogl::gui::component::Animation;
+use ensogl::gui::component::Tween;
 use ensogl::gui::component;
 
 use crate::node::NODE_SHAPE_PADDING;
@@ -22,10 +23,14 @@ use crate::node::NODE_SHAPE_RADIUS;
 // =================
 // === Constants ===
 // =================
+// TODO: These values should be in some IDE configuration.
 
-const BASE_SIZE         : f32 = 0.5;
-const HIGHLIGHT_SIZE    : f32 = 1.0;
-const SEGMENT_GAP_WIDTH : f32 = 2.0;
+const BASE_SIZE           : f32 = 0.5;
+const HIGHLIGHT_SIZE      : f32 = 1.0;
+const SEGMENT_GAP_WIDTH   : f32 = 2.0;
+
+const SHOW_DELAY_DURATION : f32 = 150.0;
+const HIDE_DELAY_DURATION : f32 = 25.0;
 
 
 
@@ -118,7 +123,7 @@ impl Frp {
 
             let port_mouse_down = on_port_mouse_down.clone_ref().into();
         }
-        Self{set_size,on_port_mouse_down,port_mouse_down}
+        Self{set_size,port_mouse_down,on_port_mouse_down}
     }
 }
 
@@ -162,12 +167,12 @@ impl OutPutPortsData {
 
         let width         = self.size.get().x;
         let height        = self.size.get().y;
-        let element_width = width / port_num;
+        let element_width = (width - NODE_SHAPE_PADDING) / port_num;
         let element_size  = Vector2::new(element_width,height);
         let gap_width     = self.gap_width.get();
 
         // Align shapes along width.
-        let x_start = -width/2.0 + NODE_SHAPE_PADDING;
+        let x_start = -width / 2.0 + NODE_SHAPE_PADDING;
         let x_delta = element_width;
         for (index, view) in self.ports.borrow().iter().enumerate(){
             view.display_object().set_parent(&self.display_object);
@@ -191,13 +196,22 @@ impl OutPutPortsData {
     }
 }
 
+
+
 // ===================
 // === OutPutPorts ===
 // ===================
 
 /// Implements the segmented output port area. Provides shapes that can be attached to a `Node` to
-/// add an interactive area with output ports. The ports appear on hover, and the currently
-/// hovered port is highlighted.
+/// add an interactive area with output ports.
+///
+/// The `OutputPorts` facilitate the falling behaviour:
+///  * when one of the output ports is hovered, after a set time, all ports are show and the hovered
+///    port is highlighted.
+///  * when a different port is hovered, it is highlighted immediately.
+///  * when none of the ports is hovered all of the `OutputPorts` disappear. Note: there is a very
+///    small delay for disappearing to allow for smooth switching between ports.
+///
 #[derive(Debug,Clone,CloneRef)]
 pub struct OutputPorts {
     /// The FRP api of the `OutPutPorts`.
@@ -228,28 +242,78 @@ impl OutputPorts {
         let frp     = &self.frp;
         let data    = &self.data;
 
+        // Used to set and detect the end of the tweens. The actual value is irrelevant, only the
+        // duration of the tween matters and that this value is reached after that time.
+        const TWEEN_END_VALUE:f32 = 1.0;
+
+        // Timer used to measure whether the hover has been long enough to show the ports.
+        let delay_show = Tween::new(&network);
+        delay_show.set_duration(SHOW_DELAY_DURATION);
+
+        // Timer used to measure whether the mouse has been gone long enough to hide all ports.
+        let delay_hide = Tween::new(&network);
+        delay_hide.set_duration(HIDE_DELAY_DURATION);
+
         frp::extend! { network
-            eval  frp.set_size ((size) data.set_size(size.into()));
 
-            def set_port_size      = source::<(PortId,f32)>();
-            def set_port_sizes_all = source::<f32>();
 
-            def _set_port_sizes = set_port_sizes_all.map(f!([set_port_size,data](size) {
-                let port_num = data.ports.borrow().len();
-                for index in 0..port_num {
-                    set_port_size.emit((index,*size));
-                };
+            // === Size Change Handling == ///
+
+            eval frp.set_size ((size) data.set_size(size.into()));
+
+
+            // === Hover Event Handling == ///
+
+            // Is emitted by the ports when they receive a MouseOver event.
+            def mouse_over           = source::<PortId>();
+            // Is emitted by the ports when they receive a MouseOut event.
+            def mouse_out            = source::<PortId>();
+
+            // Is emitted by the delay_show timer when it has finished running.
+            def on_show_delay_finish = source::<()>();
+            // Is emitted by the delay_hide timer when it has finished running.
+            def on_hide_delay_finish = source::<()>();
+            // Status indicates whether the shapes are visible or not.
+            def is_active            = source::<bool>();
+
+            // We map to (), so we can easier integrate with other events that also provide ().
+            // The actual ID of the hovered port will later again be sampled from mouse_over.
+            mouse_over_while_inactive  <- mouse_over.gate_not(&is_active).map(|_|());
+            mouse_over_while_active    <- mouse_over.gate(&is_active).map(|_|());
+
+            def _activate_show_delay = mouse_over_while_inactive.map(f_!({
+                delay_show.set_end_value(TWEEN_END_VALUE)
+            }));
+            def _activate_hide_delay = mouse_out.map(f_!({
+                delay_hide.set_end_value(TWEEN_END_VALUE)
             }));
 
-            def set_port_opacity     = source::<(PortId,f32)>();
-            def set_port_opacity_all = source::<f32>();
+            /// FIXME f! macros don't seem to support `if` statements. So this code doesn't use them
+            /// at the moment. Use them once this works.
+            let on_show_delay_finish_ref = on_show_delay_finish.clone_ref();
+            def _delay_show = delay_show.value.map(move |value| {
+                if *value == TWEEN_END_VALUE{on_show_delay_finish_ref.emit(())}
+            });
 
-            def _set_port_opacities = set_port_opacity_all.map(f!([set_port_opacity,data](size) {
-                let port_num = data.ports.borrow().len();
-                for index in 0..port_num {
-                    set_port_opacity.emit((index,*size));
-                };
-            }));
+            let on_hide_delay_finish_ref = on_hide_delay_finish.clone_ref();
+            def _delay_hide = delay_hide.value.map(move |value| {
+                if *value == TWEEN_END_VALUE {on_hide_delay_finish_ref.emit(())}
+            });
+
+            // Ports need to be visible either because we had the delay_show timer run out (that
+            // means there is an active hover) or because we had a MouseOver event before the
+            // delay_hide ran out (that means that we probably switched between ports).
+            activate_ports <- any(mouse_over_while_active,on_show_delay_finish);
+            def set_active = activate_ports.map(f_!(is_active.emit(true);delay_hide.stop()));
+
+            // This is provided for ports to act on their activation and will be used further down
+            // in the ports initialisation code.
+            def activate_ports_with_selected = mouse_over.sample(&set_active);
+
+            // This is provided for ports to hide themselves. This is used in the port
+            // Initialisation code further down.
+            def hide_all = on_hide_delay_finish.map(f_!(delay_show.rewind();is_active.emit(false)));
+
         }
 
         // Init ports
@@ -257,34 +321,52 @@ impl OutputPorts {
             let shape        = &view.shape;
             let port_size    = Animation::<f32>::new(&network);
             let port_opacity = Animation::<f32>::new(&network);
+
             frp::extend! { network
+
+
+                // === Mouse Event Handling == ///
+
+                eval_ view.events.mouse_over(mouse_over.emit(index));
+                eval_ view.events.mouse_out(mouse_out.emit(index));
+                eval_ view.events.mouse_down(frp.on_port_mouse_down.emit(index));
+
+
+                 // === Animation Handling == ///
+
                  eval port_size.value    ((size) shape.grow.set(*size));
                  eval port_opacity.value ((size) shape.opacity.set(*size));
 
-                is_resize_target <- set_port_size.map(move |(id,_)| *id == index);
-                size_change      <- set_port_size.gate(&is_resize_target);
-                eval size_change (((_, size)) port_size.set_target_value(*size));
 
-                is_opacity_target <- set_port_opacity.map(move |(id, _)| *id==index);
-                opacity_change    <- set_port_opacity.gate(&is_opacity_target);
-                eval opacity_change (((_, opacity)) port_opacity.set_target_value(*opacity));
+                // === Visibility and Highlight Handling == ///
 
-                eval_ view.events.mouse_over ([port_size,set_port_sizes_all,port_opacity,
-                                              set_port_opacity_all] {
-                    set_port_sizes_all.emit(BASE_SIZE);
-                    set_port_opacity_all.emit(0.5);
-                    port_size.set_target_value(HIGHLIGHT_SIZE);
+                 def _hide_all = hide_all.map(f_!([port_size,port_opacity]{
+                     port_size.set_target_value(0.0);
+                     port_opacity.set_target_value(0.0);
+                 }));
+
+                // Through the provided ID we can infer whether this port should be highlighted.
+                is_selected      <- activate_ports_with_selected.map(move |id| *id == index);
+                show_normal      <- activate_ports_with_selected.gate_not(&is_selected);
+                show_highlighted <- activate_ports_with_selected.gate(&is_selected);
+
+                def _show_highlighted = show_highlighted.map(f_!([port_opacity,port_size]{
                     port_opacity.set_target_value(1.0);
-                });
+                    port_size.set_target_value(HIGHLIGHT_SIZE);
+                }));
 
-                eval_ view.events.mouse_out ([set_port_sizes_all,set_port_opacity_all] {
-                     set_port_sizes_all.emit(0.0);
-                     set_port_opacity_all.emit(0.0);
-                });
-
-                eval_ view.events.mouse_down(frp.on_port_mouse_down.emit(index));
+                def _show_highlighted = show_normal.map(f_!([port_opacity,port_size]
+                    port_opacity.set_target_value(0.5);
+                    port_size.set_target_value(BASE_SIZE);
+                ));
             }
         }
+
+        // FIXME this is a hack to ensure the ports are invisible at startup.
+        // Right noe we get some of FRP mouse events on startup that leave the
+        // ports visible by default.
+        // Once that is fixed, remove this line.
+        on_hide_delay_finish.emit(());
     }
 
     // TODO: Implement proper sorting and remove.

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -538,7 +538,7 @@ pub struct OutputPortsData {
 impl OutputPortsData {
 
     fn new(scene:Scene, number_of_ports:NonZeroU32) -> Self {
-        let logger         = Logger::new("OutPutPorts");
+        let logger         = Logger::new("OutputPorts");
         let display_object = display::object::Instance::new(&logger);
         let size           = Cell::new(Vector2::zero());
         let gap_width      = Cell::new(SEGMENT_GAP_WIDTH);
@@ -681,7 +681,7 @@ impl OutputPorts {
     // TODO: Implement proper sorting and remove.
     /// Hack function used to register the elements for the sorting purposes. To be removed.
     pub(crate) fn order_hack(scene:&Scene) {
-        let logger = Logger::new("hack");
+        let logger = Logger::new("output shape order hack");
         component::ShapeView::<multi_port_area::Shape>::new(&logger, scene);
     }
 }

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -309,6 +309,8 @@ pub mod single_port_area {
             let color     = Var::<color::Rgba>::from("srgba(0.25,0.58,0.91,input_opacity)");
             let port_area = port_area.fill(color);
 
+            let hover_area = hover_area.fill(color::Rgba::new(0.0,0.0,0.0,0.000_001));
+
             (port_area + hover_area).into()
         }
     }
@@ -684,6 +686,7 @@ impl OutputPorts {
     pub(crate) fn order_hack(scene:&Scene) {
         let logger = Logger::new("output shape order hack");
         component::ShapeView::<multi_port_area::Shape>::new(&logger,scene);
+        component::ShapeView::<single_port_area::Shape>::new(&logger,scene);
     }
 }
 

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -645,11 +645,11 @@ impl OutputPorts {
             });
 
             activate_ports <- any(mouse_over_while_active,on_delay_show_finished);
-            eval_ activate_ports (delay_hide.stop());
+            eval_ activate_ports (delay_hide.stop_and_rewind());
 
             activate_ports_with_selected <- port_mouse_over.sample(&activate_ports);
 
-            hide_all <- on_delay_hide_finished.map(f_!(delay_show.stop()));
+            hide_all <- on_delay_hide_finished.map(f_!(delay_show.stop_and_rewind()));
 
         }
 

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -12,7 +12,6 @@ use ensogl::display::shape::*;
 use ensogl::display::traits::*;
 use ensogl::display;
 use ensogl::gui::component::Animation;
-use ensogl::gui::component::Tween;
 use ensogl::gui::component;
 
 use crate::node::NODE_SHAPE_PADDING;
@@ -28,9 +27,6 @@ use crate::node::NODE_SHAPE_RADIUS;
 const BASE_SIZE           : f32 = 0.5;
 const HIGHLIGHT_SIZE      : f32 = 1.0;
 const SEGMENT_GAP_WIDTH   : f32 = 2.0;
-
-const SHOW_DELAY_DURATION : f32 = 150.0;
-const HIDE_DELAY_DURATION : f32 = 25.0;
 
 
 
@@ -243,13 +239,13 @@ impl OutputPorts {
         let data    = &self.data;
 
         frp::extend! { network
-            eval  frp.set_size ((size) data.borrow_mut().set_size(size.into()));
+            eval  frp.set_size ((size) data.set_size(size.into()));
 
             def set_port_size      = source::<(PortId,f32)>();
             def set_port_sizes_all = source::<f32>();
 
             def _set_port_sizes = set_port_sizes_all.map(f!([set_port_size,data](size) {
-                let port_num = data.borrow().ports.borrow().len();
+                let port_num = data.ports.borrow().len();
                 for index in 0..port_num {
                     set_port_size.emit((index,*size));
                 };
@@ -259,7 +255,7 @@ impl OutputPorts {
             def set_port_opacity_all = source::<f32>();
 
             def _set_port_opacities = set_port_opacity_all.map(f!([set_port_opacity,data](size) {
-                let port_num = data.borrow().ports.borrow().len();
+                let port_num = data.ports.borrow().len();
                 for index in 0..port_num {
                     set_port_opacity.emit((index,*size));
                 };
@@ -267,7 +263,7 @@ impl OutputPorts {
         }
 
         // Init ports
-        for (index,view) in data.borrow().ports.borrow().iter().enumerate() {
+        for (index,view) in data.ports.borrow().iter().enumerate() {
             let shape        = &view.shape;
             let port_size    = Animation::<f32>::new(&network);
             let port_opacity = Animation::<f32>::new(&network);
@@ -299,12 +295,6 @@ impl OutputPorts {
                 eval_ view.events.mouse_down(frp.on_port_mouse_down.emit(index));
             }
         }
-
-        // FIXME this is a hack to ensure the ports are invisible at startup.
-        // Right noe we get some of FRP mouse events on startup that leave the
-        // ports visible by default.
-        // Once that is fixed, remove this line.
-        on_hide_delay_finish.emit(());
     }
 
     // TODO: Implement proper sorting and remove.

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -13,6 +13,7 @@ use ensogl::display::traits::*;
 use ensogl::display;
 use ensogl::gui::component::Animation;
 use ensogl::gui::component;
+
 use crate::node::NODE_SHAPE_PADDING;
 
 
@@ -21,9 +22,9 @@ use crate::node::NODE_SHAPE_PADDING;
 // === Constants ===
 // =================
 
-const BASE_SIZE:f32         = 0.5;
-const HIGHLIGHT_SIZE:f32    = 1.0;
-const SEGMENT_GAP_WIDTH:f32 = 2.0;
+const BASE_SIZE         : f32 = 0.5;
+const HIGHLIGHT_SIZE    : f32 = 1.0;
+const SEGMENT_GAP_WIDTH : f32 = 2.0;
 
 
 
@@ -88,10 +89,11 @@ pub mod port_area {
     }
 }
 
+
+
 // ===========
 // === Frp ===
 // ===========
-
 
 type PortId = usize;
 
@@ -246,14 +248,14 @@ impl OutputPorts {
         // Init ports
         {
             for (index,view) in data.borrow().ports.iter().enumerate() {
-                let shape          = &view.shape;
+                let shape        = &view.shape;
                 let port_size    = Animation::<f32>::new(&network);
                 let port_opacity = Animation::<f32>::new(&network);
                 frp::extend! { network
-                     eval port_size.value ((size) shape.grow.set(*size));
-                     eval port_opacity.value   ((size) shape.opacity.set(*size));
+                     eval port_size.value    ((size) shape.grow.set(*size));
+                     eval port_opacity.value ((size) shape.opacity.set(*size));
 
-                    is_resize_target <- set_port_size.map(move |(id, _)| *id==index);
+                    is_resize_target <- set_port_size.map(move |(id,_)| *id == index);
                     size_change      <- set_port_size.gate(&is_resize_target);
                     _change_size     <- size_change.map(f!(((_, size))  {
                         port_size.set_target_value(*size)
@@ -265,7 +267,8 @@ impl OutputPorts {
                         port_opacity.set_target_value(*opacity)
                     }));
 
-                    eval view.events.mouse_over ([port_size,set_port_sizes_all,port_opacity,set_port_opacity_all](_) {
+                    eval view.events.mouse_over ([port_size,set_port_sizes_all,port_opacity,
+                                                  set_port_opacity_all](_) {
                         set_port_sizes_all.emit(BASE_SIZE);
                         set_port_opacity_all.emit(0.5);
                         port_size.set_target_value(HIGHLIGHT_SIZE);

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -251,23 +251,23 @@ pub mod multi_port_area {
             let radius:Var::<f32> = radius.into();
             let width:Var::<f32>  = width.into();
 
-            // Crop planes for the visible port area. Includes padding.
             let left_shape_crop  = compute_crop_plane
-                (&index,&port_num,&width,&radius,&padding_left);
+                (&index,&port_num,&width,&radius,&0.0.into());
             let right_shape_crop = compute_crop_plane
-                (&(Var::<f32>::from(1.0) + &index),&port_num,&width,&radius,&padding_right);
+                (&(Var::<f32>::from(1.0) + &index),&port_num,&width,&radius,&0.0.into());
+
+            let hover_area = hover_area.difference(&left_shape_crop);
+            let hover_area = hover_area.intersection(&right_shape_crop);
+            let hover_area = hover_area.fill(color::Rgba::new(0.0,0.0,0.0,0.000_001));
+
+            let padding_left = Var::<Distance<Pixels>>::from(padding_left);
+            let padding_right = Var::<Distance<Pixels>>::from(padding_right);
+
+            let left_shape_crop  = left_shape_crop.grow(padding_left);
+            let right_shape_crop = right_shape_crop.grow(padding_right);
 
             let port_area  = port_area.difference(&left_shape_crop);
             let port_area  = port_area.intersection(&right_shape_crop);
-
-            // Crop planes for the invisible hover area. No padding.
-            let left_hover_crop  = compute_crop_plane(&index,&port_num,&width,&radius,&0.0.into());
-            let right_hover_crop = compute_crop_plane
-                (&(Var::<f32>::from(1.0) + &index),&port_num,&width,&radius,&0.0.into());
-
-            let hover_area = hover_area.difference(&left_hover_crop);
-            let hover_area = hover_area.intersection(&right_hover_crop);
-            let hover_area = hover_area.fill(color::Rgba::new(0.0,0.0,0.0,0.000_001));
 
             // FIXME: Use color from style and apply transparency there.
             let color     = Var::<color::Rgba>::from("srgba(0.25,0.58,0.91,input_opacity)");

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -101,7 +101,10 @@ pub mod port_area {
 // ===========
 
 /// Id of a specific port inside of `OutPutPortsData`.
-type PortId = usize;
+#[derive(Clone,Copy,Default,Debug)]
+pub struct PortId {
+    index: usize,
+}
 
 /// Frp API of the `OutPutPorts`.
 #[derive(Clone,CloneRef,Debug)]
@@ -305,9 +308,9 @@ impl OutputPorts {
 
                 // === Mouse Event Handling == ///
 
-                eval_ view.events.mouse_over(port_mouse_over.emit(index));
-                eval_ view.events.mouse_out(port_mouse_out.emit(index));
-                eval_ view.events.mouse_down(frp.on_port_mouse_down.emit(index));
+                eval_ view.events.mouse_over(port_mouse_over.emit(PortId{index}));
+                eval_ view.events.mouse_out(port_mouse_out.emit(PortId{index}));
+                eval_ view.events.mouse_down(frp.on_port_mouse_down.emit(PortId{index}));
 
 
                  // === Animation Handling == ///
@@ -324,7 +327,7 @@ impl OutputPorts {
                  }));
 
                 // Through the provided ID we can infer whether this port should be highlighted.
-                is_selected      <- activate_ports_with_selected.map(move |id| *id == index);
+                is_selected      <- activate_ports_with_selected.map(move |id| id.index == index);
                 show_normal      <- activate_ports_with_selected.gate_not(&is_selected);
                 show_highlighted <- activate_ports_with_selected.gate(&is_selected);
 

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -186,7 +186,7 @@ impl OutputPortsData {
             view.set_position_xy(pos);
 
             let shape = &view.shape;
-            shape.sprite.size().set(port_size);
+            shape.sprite.size.set(port_size);
             shape.shape_width.set(width);
             shape.padding.set(gap_width);
             shape.offset_x.set(x_delta * index as f32);

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -99,7 +99,7 @@ type PortId = usize;
 
 #[derive(Clone,CloneRef,Debug)]
 pub struct Frp {
-    pub set_size        : frp::Source<Option<Vector2<f32>>>,
+    pub set_size        : frp::Source<V2<f32>>,
     pub port_mouse_down : frp::Stream<PortId>,
 
     on_port_mouse_down  : frp::Source<PortId>,
@@ -222,7 +222,7 @@ impl OutputPorts {
         let data    = &self.data;
 
         frp::extend! { network
-            eval  frp.set_size ((size) data.borrow_mut().set_size(size.unwrap_or_else(zero)));
+            eval  frp.set_size ((size) data.borrow_mut().set_size(size.into()));
 
             def set_port_size      = source::<(PortId,f32)>();
             def set_port_sizes_all = source::<f32>();

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -656,7 +656,7 @@ impl OutputPorts {
         // // Right now we get some of FRP mouse events on startup that leave the
         // // ports visible by default.
         // // Once that is fixed, remove this line.
-        // delay_hide.finish();
+        delay_hide.finish();
     }
 
     // TODO: Implement proper sorting and remove.

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -47,9 +47,9 @@ const SHAPE_MAX_WIDTH       : f32 = 4.0;
 
 
 
-// ==============
-// === Shapes ===
-// ==============
+// ==================
+// === Base Shape ===
+// ==================
 
 /// The base port shape for the output port shape. This shape is later on used to create a
 /// simple single output port shape and a more complex multi-output port shape.
@@ -115,6 +115,12 @@ trait PortShape {
     fn set_grow(&self, grow_value:f32);
     fn set_opacity(&self, opacity:f32);
 }
+
+
+
+// ========================
+// === Multi Port Shape ===
+// ========================
 
 /// Implements the shape for a segment of the OutputPort with multiple output ports.
 pub mod multi_port_area {
@@ -284,6 +290,12 @@ pub mod multi_port_area {
     }
 }
 
+
+
+// =========================
+// === Single Port Shape ===
+// =========================
+
 /// Implements a simplified version of the multi_port_area::Shape shape for the case where there is
 /// only a single output port.
 pub mod single_port_area {
@@ -316,6 +328,12 @@ pub mod single_port_area {
         }
     }
 }
+
+
+
+// ==================
+// === Shape View ===
+// ==================
 
 /// Helper enum that handles the distinction between a single shape output area and a multi port
 /// output area.
@@ -389,9 +407,9 @@ impl ShapeView {
 
 
 
-// =============================
-// === Port Frp Setup Helper ===
-// =============================
+// =================
+// === Port Frp  ===
+// =================
 
 /// Helper struct to pass the required FRP endpoints to set up the FRP of a port shape view.
 #[derive(Clone,CloneRef,Debug)]

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -108,7 +108,7 @@ impl BaseShapeData {
     }
 }
 
-/// Helper trait that allows us to abstract the API of the `multi_port_area::Shape` and the
+/// Trait that allows us to abstract the API of the `multi_port_area::Shape` and the
 /// `single_port_area::Shape`. This is needed to avoid code duplication for functionality that can
 /// work with either shape.
 #[allow(missing_docs)]
@@ -133,7 +133,7 @@ pub mod multi_port_area {
     fn in_range_inclusive
     (value:&Var<f32>, lower_bound:&Var<f32>, upper_bound:&Var<f32>) -> Var<f32> {
         Var::<f32>::from(format!("(step(float({1}),float({0})) * step(float({0}),float({2})))",
-                                 value, ower_bound,upper_bound))
+                                 value, lower_bound,upper_bound))
     }
 
     /// Compute the angle perpendicular to the shape border.
@@ -330,11 +330,11 @@ pub mod single_port_area {
 // === Shape View ===
 // ==================
 
-/// Helper enum that handles the distinction between a single shape output area and a multi port
-/// output area.
+/// Wrapper that handles the distinction between a single ShapeView<single_port_area::Shape>
+/// and collection of component::ShapeView<multi_port_area::Shape>.
 #[derive(Clone,Debug)]
 enum ShapeView {
-    Single { view  : component::ShapeView<multi_port_area::Shape>      },
+    Single { view  : component::ShapeView<single_port_area::Shape> },
     Multi  {
         display_object: display::object::Instance,
         views : Vec<component::ShapeView<multi_port_area::Shape>>,
@@ -427,7 +427,7 @@ impl PortId {
 // === Port Frp  ===
 // =================
 
-/// Helper struct to pass the required FRP endpoints to set up the FRP of a port shape view.
+/// Struct that contains all required FRP endpoints to set up the FRP of a port shape view.
 #[derive(Clone,CloneRef,Debug)]
 struct PortFrp {
     mouse_over                            : frp::Source<PortId>,

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -160,7 +160,6 @@ impl OutPutPortsData {
 
     fn update_shape_layout_based_on_size(&self) {
         let port_num    = self.ports.borrow().len() as f32;
-
         let width       = self.size.get().x;
         let height      = self.size.get().y;
         let port_width  = (width - NODE_SHAPE_PADDING) / port_num;

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -288,7 +288,7 @@ impl OutputPorts {
 
     // TODO: Implement proper sorting and remove.
     /// Hack function used to register the elements for the sorting purposes. To be removed.
-    pub(crate) fn init_shape_order_hack(scene:&Scene) {
+    pub(crate) fn order_hack(scene:&Scene) {
         let logger = Logger::new("hack");
         component::ShapeView::<port_area::Shape>::new(&logger,scene);
     }

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -163,12 +163,13 @@ impl OutputPortsData {
     }
 
     fn update_shape_layout_based_on_size(&self) {
-        let port_num   = self.ports.borrow().len() as f32;
-        let width      = self.size.get().x;
-        let height     = self.size.get().y;
-        let port_width = (width - node::NODE_SHAPE_PADDING) / port_num;
-        let port_size  = Vector2::new(port_width, height);
-        let gap_width  = self.gap_width.get();
+        let port_num    = self.ports.borrow().len() as f32;
+        let width       = self.size.get().x;
+        let width_inner = width - 2.0 * node::NODE_SHAPE_PADDING + 2.0 * node::SHADOW_SIZE;
+        let height      = self.size.get().y;
+        let port_width  = (width_inner) / port_num;
+        let port_size   = Vector2::new(port_width, height);
+        let gap_width   = self.gap_width.get();
 
         // Align shapes along width.
         let x_start = -width / 2.0 + node::NODE_SHAPE_PADDING;

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -608,12 +608,7 @@ impl OutputPorts {
         OutputPorts {data,network,frp}.init()
     }
 
-    fn init(mut self) -> Self {
-        self.init_frp();
-        self
-    }
-
-    fn init_frp(&mut self) {
+    fn init(self) -> Self {
         let network = &self.network;
         let frp     = &self.frp;
         let data    = &self.data;
@@ -685,6 +680,8 @@ impl OutputPorts {
         // // ports visible by default.
         // // Once that is fixed, remove this line.
         delay_hide.from_now_to(TWEEN_END_VALUE);
+
+        self
     }
 
     // TODO: Implement proper sorting and remove.

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -966,7 +966,8 @@ impl GraphEditorModelWithNetwork {
         frp::new_bridge_network! { [self.network, node.main_area.events.network]
             eval_ node.drag_area.events.mouse_down(touch.nodes.down.emit(node_id));
             eval  node.ports.frp.cursor_style ((style) cursor_style.emit(style));
-            eval_ node.frp.output_ports.mouse_down (output_press.emit(node_id));
+            eval_ node.view.output_ports.frp.port_mouse_down (output_press.emit(node_id));
+            eval_ node.view.output_ports.frp.port_mouse_down (output_press.emit(node_id));
             eval  node.ports.frp.press ([input_press](crumbs)
                 let target = EdgeTarget::new(node_id,crumbs.clone());
                 input_press.emit(target);

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -978,12 +978,12 @@ impl GraphEditorModelWithNetwork {
                 model.frp.hover_node_input.emit(target);
             });
 
-             eval_ node.frp.output_ports.mouse_over ([model] {
+             eval_ node.view.output_ports.frp.port_mouse_over ([model] {
                 let target = EdgeTarget::new(node_id,default());
                 model.frp.hover_node_output.emit(Some(target));
              });
 
-             eval_ node.frp.output_ports.mouse_out ( model.frp.hover_node_output.emit(None));
+             eval_ node.view.output_ports.frp.port_mouse_out ( model.frp.hover_node_output.emit(None));
         }
 
 //        self.visualizations.push(node.visualization().clone_ref());


### PR DESCRIPTION
### Pull Request Description
Adds multiple output ports to nodes that are highlighted on hover.

![Peek 2020-06-15 10-26](https://user-images.githubusercontent.com/1428930/84634944-ce9dfb00-aef2-11ea-8122-19208a34aeb6.gif)

### Important notes
* hack: there is not yet a good way to manage the order of shapes. To compensate for this a method that initializes the shapes is provided and called at the right place to ensure the correct order of shapes. The correct management needs to be still implemented once shape order management is available.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

