### PR TITLE
Correctly invalidate line offsets after setting the text field's content

### DIFF
--- a/src/rust/lib/data/src/text.rs
+++ b/src/rust/lib/data/src/text.rs
@@ -11,7 +11,6 @@ use serde::Serialize;
 use serde::Deserialize;
 
 
-
 /// ======================================
 /// === Text Coordinates And Distances ===
 /// ======================================
@@ -210,6 +209,13 @@ pub struct TextLocation {
     pub line: usize,
     /// Column is a index of char in given line.
     pub column: usize,
+}
+
+/// Short pretty print representation in the form of `line:column`.
+impl Display for TextLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f,"{}:{}",self.line,self.column)
+    }
 }
 
 impl TextLocation {


### PR DESCRIPTION
### Pull Request Description
There are two ways to change the conent of the text field: either applying edits or using `set_content` method to replace it totally.
The latter lacked proper invalidation for the `line_offsets`, leading to invalid index recalculations later.


### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
- [ ] All code has been profiled where possible.

