### PR TITLE
Bump parser to fix metadata loss on entering a newline

### DIFF
--- a/src/rust/ide/parser/build.rs
+++ b/src/rust/ide/parser/build.rs
@@ -25,7 +25,7 @@ use std::path::PathBuf;
 const PARSER_PATH: &str = "./pkg/scala-parser.js";
 
 /// Commit from `enso` repository that will be used to obtain parser from.
-const PARSER_COMMIT: &str = "81bde2858900e61fcab4138dc8881757a0787dfa";
+const PARSER_COMMIT: &str = "b105bc1f013f9c262102d8f59869c0a5617085d0";
 
 /// Magic code that needs to be prepended to ScalaJS generated parser due to:
 /// https://github.com/scala-js/scala-js/issues/3677/
@@ -89,7 +89,9 @@ impl ParserProvider {
         let url            = parser_url(&self.version);
         let get_error      = format!("Failed to get response from {}.",    url);
         let download_error = format!("Failed to download contents of {}.", url);
+        let server_error   = format!("Server replied with error when getting {}.", url);
         let response = reqwest::get(url).await.expect(&get_error);
+        let response = response.error_for_status().expect(&server_error);
         response.bytes().await.expect(&download_error)
     }
 

--- a/src/rust/ide/parser/build.rs
+++ b/src/rust/ide/parser/build.rs
@@ -90,8 +90,8 @@ impl ParserProvider {
         let get_error      = format!("Failed to get response from {}.",    url);
         let download_error = format!("Failed to download contents of {}.", url);
         let server_error   = format!("Server replied with error when getting {}.", url);
-        let response = reqwest::get(url).await.expect(&get_error);
-        let response = response.error_for_status().expect(&server_error);
+        let response       = reqwest::get(url).await.expect(&get_error);
+        let response       = response.error_for_status().expect(&server_error);
         response.bytes().await.expect(&download_error)
     }
 

--- a/src/rust/ide/parser/tests/id_map.rs
+++ b/src/rust/ide/parser/tests/id_map.rs
@@ -1,22 +1,29 @@
+use parser::prelude::*;
+
 use parser::Parser;
-use enso_prelude::default;
 use ast::HasIdMap;
+use wasm_bindgen_test::wasm_bindgen_test;
+use wasm_bindgen_test::wasm_bindgen_test_configure;
 
+wasm_bindgen_test_configure!(run_in_browser);
 
-
-#[ignore]
-#[test]
-fn parsing_main_with_id_map() {
-    const CASES : &[&str] = &
+#[wasm_bindgen_test]
+fn id_map_round_tripping() {
+    let cases =
         [ "main =\n    2 + 2"
         , "main =   \n \n    2 + 2\n    foo = bar \n    baz"
+        , "main = \n    foo\n\n    bar"
+        , "main = \n    foo\n  \n    bar"
+        , "main = \n    foo\n     \n    bar"
+        , "main = \n    foo\n    baz \n    bar"
         ];
 
-    for case in CASES {
-        let parser = Parser::new().unwrap();
-        let ast1 = parser.parse(case.to_string(),default()).unwrap();
+    let parser = Parser::new().unwrap();
+    for case in cases.iter().copied() {
+        let id_map = default();
+        let ast1 = parser.parse_module(case,id_map).unwrap();
         let id_map = ast1.id_map();
-        let ast2 = parser.parse(case.to_string(),id_map).unwrap();
+        let ast2 = parser.parse_module(case,id_map).unwrap();
         assert_eq!(ast1,ast2)
     }
 }

--- a/src/rust/ide/parser/tests/id_map.rs
+++ b/src/rust/ide/parser/tests/id_map.rs
@@ -1,7 +1,7 @@
 use parser::prelude::*;
 
-use parser::Parser;
 use ast::HasIdMap;
+use parser::Parser;
 use wasm_bindgen_test::wasm_bindgen_test;
 use wasm_bindgen_test::wasm_bindgen_test_configure;
 


### PR DESCRIPTION
### Pull Request Description
This PR:
* bumps the parser version so the issue with id mapping when there is an empty line in block is fixed ( https://github.com/luna/enso/pull/808 );
* enables test for id map handling and adds more case to cover the parser's fix;
* adds proper error handling in the build.rs — we may get a reply but this reply may contain an error which was previously not recognized.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
- [ ] All code has been profiled where possible.

