### PR TITLE
 Delayed appearance of multi ports

### DIFF
--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -26,6 +26,9 @@ const BASE_SIZE           : f32 = 0.5;
 const HIGHLIGHT_SIZE      : f32 = 1.0;
 const SEGMENT_GAP_WIDTH   : f32 = 2.0;
 
+const SHOW_DELAY_DURATION : f32 = 150.0;
+const HIDE_DELAY_DURATION : f32 = 25.0;
+
 
 
 // ==============
@@ -354,6 +357,12 @@ impl OutputPorts {
                 ));
             }
         }
+
+        // FIXME this is a hack to ensure the ports are invisible at startup.
+        // Right noe we get some of FRP mouse events on startup that leave the
+        // ports visible by default.
+        // Once that is fixed, remove this line.
+        on_hide_delay_finish.emit(());
     }
 
     // TODO: Implement proper sorting and remove.

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -235,29 +235,78 @@ impl OutputPorts {
         let frp     = &self.frp;
         let data    = &self.data;
 
+        // Used to set and detect the end of the tweens. The actual value is irrelevant, only the
+        // duration of the tween matters and that this value is reached after that time.
+        const TWEEN_END_VALUE:f32 = 1.0;
+
+        // Timer used to measure whether the hover has been long enough to show the ports.
+        let delay_show = Tween::new(&network);
+        delay_show.set_duration(SHOW_DELAY_DURATION);
+
+        // Timer used to measure whether the mouse has been gone long enough to hide all ports.
+        let delay_hide = Tween::new(&network);
+        delay_hide.set_duration(HIDE_DELAY_DURATION);
+
         frp::extend! { network
-            eval  frp.set_size ((size) data.set_size(size.into()));
 
-            set_port_size      <- source::<(PortId,f32)>();
-            set_port_sizes_all <- source::<f32>();
 
-            eval set_port_sizes_all ([set_port_size,data](size) {
-                let port_num = data.ports.borrow().len();
-                for index in 0..port_num {
-                    set_port_size.emit((index,*size));
-                };
-            });
+            // === Size Change Handling == ///
 
-            set_port_opacity     <- source::<(PortId,f32)>();
-            set_port_opacity_all <- source::<f32>();
+            eval frp.set_size ((size) data.set_size(size.into()));
 
-            port_ix_to_change   <= set_port_opacity_all.map(f_!([data] {
-                Vec::<usize>::from_iter(0..data.ports.borrow().len())
+
+            // === Hover Event Handling == ///
+
+            // Is emitted by the ports when they receive a MouseOver event.
+            def mouse_over           = source::<PortId>();
+            // Is emitted by the ports when they receive a MouseOut event.
+            def mouse_out            = source::<PortId>();
+
+            // Is emitted by the delay_show timer when it has finished running.
+            def on_show_delay_finish = source::<()>();
+            // Is emitted by the delay_hide timer when it has finished running.
+            def on_hide_delay_finish = source::<()>();
+            // Status indicates whether the shapes are visible or not.
+            def is_active            = source::<bool>();
+
+            // We map to (), so we can easier integrate with other events that also provide ().
+            // The actual ID of the hovered port will later again be sampled from mouse_over.
+            mouse_over_while_inactive  <- mouse_over.gate_not(&is_active).map(|_|());
+            mouse_over_while_active    <- mouse_over.gate(&is_active).map(|_|());
+
+            def _activate_show_delay = mouse_over_while_inactive.map(f_!({
+                delay_show.set_end_value(TWEEN_END_VALUE)
             }));
-            set_port_opacity_for_port    <- all(&port_ix_to_change,&set_port_opacity_all);
-            eval set_port_opacity_for_port ([set_port_opacity]((index, opacity)) {
-               set_port_opacity.emit((*index,*opacity));
+            def _activate_hide_delay = mouse_out.map(f_!({
+                delay_hide.set_end_value(TWEEN_END_VALUE)
+            }));
+
+            /// FIXME f! macros don't seem to support `if` statements. So this code doesn't use them
+            /// at the moment. Use them once this works.
+            let on_show_delay_finish_ref = on_show_delay_finish.clone_ref();
+            def _delay_show = delay_show.value.map(move |value| {
+                if *value == TWEEN_END_VALUE{on_show_delay_finish_ref.emit(())}
             });
+
+            let on_hide_delay_finish_ref = on_hide_delay_finish.clone_ref();
+            def _delay_hide = delay_hide.value.map(move |value| {
+                if *value == TWEEN_END_VALUE {on_hide_delay_finish_ref.emit(())}
+            });
+
+            // Ports need to be visible either because we had the delay_show timer run out (that
+            // means there is an active hover) or because we had a MouseOver event before the
+            // delay_hide ran out (that means that we probably switched between ports).
+            activate_ports <- any(mouse_over_while_active,on_show_delay_finish);
+            def set_active = activate_ports.map(f_!(is_active.emit(true);delay_hide.stop()));
+
+            // This is provided for ports to act on their activation and will be used further down
+            // in the ports initialisation code.
+            def activate_ports_with_selected = mouse_over.sample(&set_active);
+
+            // This is provided for ports to hide themselves. This is used in the port
+            // Initialisation code further down.
+            def hide_all = on_hide_delay_finish.map(f_!(delay_show.rewind();is_active.emit(false)));
+
         }
 
         // Init ports
@@ -265,32 +314,44 @@ impl OutputPorts {
             let shape        = &view.shape;
             let port_size    = Animation::<f32>::new(&network);
             let port_opacity = Animation::<f32>::new(&network);
+
             frp::extend! { network
+
+
+                // === Mouse Event Handling == ///
+
+                eval_ view.events.mouse_over(mouse_over.emit(index));
+                eval_ view.events.mouse_out(mouse_out.emit(index));
+                eval_ view.events.mouse_down(frp.on_port_mouse_down.emit(index));
+
+
+                 // === Animation Handling == ///
+
                  eval port_size.value    ((size) shape.grow.set(*size));
                  eval port_opacity.value ((size) shape.opacity.set(*size));
 
-                is_resize_target <- set_port_size.map(move |(id,_)| *id == index);
-                size_change      <- set_port_size.gate(&is_resize_target);
-                eval size_change (((_, size)) port_size.set_target_value(*size));
 
-                is_opacity_target <- set_port_opacity.map(move |(id, _)| *id==index);
-                opacity_change    <- set_port_opacity.gate(&is_opacity_target);
-                eval opacity_change (((_, opacity)) port_opacity.set_target_value(*opacity));
+                // === Visibility and Highlight Handling == ///
 
-                eval_ view.events.mouse_over ([port_size,set_port_sizes_all,port_opacity,
-                                              set_port_opacity_all] {
-                    set_port_sizes_all.emit(BASE_SIZE);
-                    set_port_opacity_all.emit(0.5);
-                    port_size.set_target_value(HIGHLIGHT_SIZE);
+                 def _hide_all = hide_all.map(f_!([port_size,port_opacity]{
+                     port_size.set_target_value(0.0);
+                     port_opacity.set_target_value(0.0);
+                 }));
+
+                // Through the provided ID we can infer whether this port should be highlighted.
+                is_selected      <- activate_ports_with_selected.map(move |id| *id == index);
+                show_normal      <- activate_ports_with_selected.gate_not(&is_selected);
+                show_highlighted <- activate_ports_with_selected.gate(&is_selected);
+
+                def _show_highlighted = show_highlighted.map(f_!([port_opacity,port_size]{
                     port_opacity.set_target_value(1.0);
-                });
+                    port_size.set_target_value(HIGHLIGHT_SIZE);
+                }));
 
-                eval_ view.events.mouse_out ([set_port_sizes_all,set_port_opacity_all] {
-                     set_port_sizes_all.emit(0.0);
-                     set_port_opacity_all.emit(0.0);
-                });
-
-                eval_ view.events.mouse_down(frp.on_port_mouse_down.emit(index));
+                def _show_highlighted = show_normal.map(f_!([port_opacity,port_size]
+                    port_opacity.set_target_value(0.5);
+                    port_size.set_target_value(BASE_SIZE);
+                ));
             }
         }
     }

--- a/src/rust/lib/graph-editor/src/component/node/port/output.rs
+++ b/src/rust/lib/graph-editor/src/component/node/port/output.rs
@@ -12,6 +12,7 @@ use ensogl::display::Sprite;
 use ensogl::display::scene::Scene;
 use ensogl::display;
 use ensogl::gui::component::Animation;
+use ensogl::gui::component::Tween;
 use ensogl::gui::component;
 
 use crate::node;


### PR DESCRIPTION
### Pull Request Description
Adds a delay to the visibility onset on ports. This avoids the blinking of ports during mouse movements over nodes that are not intended to interact with the node.

![Peek 2020-06-05 14-01](https://user-images.githubusercontent.com/1428930/83875208-fc3ab580-a736-11ea-968c-77042c3837ed.gif)

### Important Notes
* hack: there are some invalid mouse events on startup that would leave the ports visible by default. This is compensated for by manually hiding the ports, even though this would otherwise b the default state.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

