### PR TITLE
Fixed textfield key masking on Mac

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.16.1'
+          node-version: '12.18.0'
 
       - name: Build
         run: node ./run dist

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.16.1'
+          node-version: '12.18.0'
 
       - name: Building Rust Sources
         run: node ./run lint
@@ -121,7 +121,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.16.1'
+          node-version: '12.18.0'
 
       - name: Run tests
         run: node ./run test --no-wasm
@@ -168,7 +168,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.16.1'
+          node-version: '12.18.0'
 
       - name: Run tests
         run: node ./run test --no-native
@@ -190,7 +190,7 @@ jobs:
   #     - name: Install Node
   #       uses: actions/setup-node@v1
   #       with:
-  #         node-version: '12.16.1'
+  #         node-version: '12.18.0'
   #
   #     - name: Generate test profile
   #       working-directory: src/rust

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.16.1'
+          node-version: '12.18.0'
 
       - name: Build
         run: node ./run build

--- a/run
+++ b/run
@@ -12,8 +12,8 @@ let args = process.argv.slice(2)
 let no_validation = '--no-validation'
 async function init () {
     if(!args.includes(no_validation)) {
-        await cmd.check_version('npm','6.13.4',{silent:true})
-        await cmd.check_version('node','v12.16.1',{silent:true})
+        await cmd.check_version('npm','6.14.4',{silent:true})
+        await cmd.check_version('node','v12.18.0',{silent:true})
         await cmd.check_version('rustc','1.40.0-nightly',{
             preprocess:(v)=>v.substring(6,20),silent:true
         })

--- a/src/rust/ensogl/src/display/shape/text/text_field/frp/keyboard.rs
+++ b/src/rust/ensogl/src/display/shape/text/text_field/frp/keyboard.rs
@@ -133,7 +133,7 @@ impl TextFieldKeyboardFrp {
         }
     }
 
-    fn enable_writing(mask:&keyboard::KeyMask) -> bool {
+    fn enables_writing(mask:&keyboard::KeyMask) -> bool {
         let modifiers = &[keyboard::Key::Control,keyboard::Key::Alt,keyboard::Key::Meta];
         let is_modifier  = modifiers.iter().any(|key| mask.contains(key));
         let is_alt_graph = mask.contains(&keyboard::Key::AltGraph);
@@ -141,7 +141,6 @@ impl TextFieldKeyboardFrp {
             // On Windows AltGraph is emitted as both AltGraph and Ctrl. Therefore we don't
             // care about modifiers when AltGraph is pressed.
             Platform::Windows => !is_modifier || is_alt_graph,
-            //TODO[dg]: Test on Linux.
             _                 => !is_modifier
         }
     }
@@ -150,7 +149,7 @@ impl TextFieldKeyboardFrp {
         move |key,mask| {
             text_field.upgrade().for_each(|text_field| {
                 if let keyboard::Key::Character(string) = key {
-                    if Self::enable_writing(mask) {
+                    if Self::enables_writing(mask) {
                         text_field.write(string);
                     }
                 }

--- a/src/rust/ensogl/src/display/shape/text/text_field/frp/keyboard.rs
+++ b/src/rust/ensogl/src/display/shape/text/text_field/frp/keyboard.rs
@@ -133,16 +133,24 @@ impl TextFieldKeyboardFrp {
         }
     }
 
+    fn enable_writing(mask:&keyboard::KeyMask) -> bool {
+        let modifiers = &[keyboard::Key::Control,keyboard::Key::Alt,keyboard::Key::Meta];
+        let is_modifier  = modifiers.iter().any(|key| mask.contains(key));
+        let is_alt_graph = mask.contains(&keyboard::Key::AltGraph);
+        match Platform::query() {
+            // On Windows AltGraph is emitted as both AltGraph and Ctrl. Therefore we don't
+            // care about modifiers when AltGraph is pressed.
+            Platform::Windows => !is_modifier || is_alt_graph,
+            //TODO[dg]: Test on Linux.
+            _                 => !is_modifier
+        }
+    }
+
     fn char_typed_lambda(text_field:WeakTextField) -> impl Fn(&keyboard::Key,&keyboard::KeyMask) {
         move |key,mask| {
             text_field.upgrade().for_each(|text_field| {
                 if let keyboard::Key::Character(string) = key {
-                    let modifiers = &[keyboard::Key::Control,keyboard::Key::Alt];
-                    let is_modifier  = modifiers.iter().any(|key| mask.contains(key));
-                    let is_alt_graph = mask.contains(&keyboard::Key::AltGraph);
-                    // On Windows AltGraph is emitted as both AltGraph and Ctrl. Therefore we don't
-                    // care about modifiers when AltGraph is pressed.
-                    if  !is_modifier || is_alt_graph {
+                    if Self::enable_writing(mask) {
                         text_field.write(string);
                     }
                 }

--- a/src/rust/ide/src/view/text_editor.rs
+++ b/src/rust/ide/src/view/text_editor.rs
@@ -14,6 +14,7 @@ use ensogl::display::shape::text::text_field::TextField;
 use ensogl::display::shape::text::text_field::TextFieldProperties;
 use ensogl::display::world::*;
 use ensogl::display;
+use ensogl::system::web::platform::Platform;
 use nalgebra::Vector2;
 use nalgebra::zero;
 use utils::channel::process_stream_with_handle;
@@ -88,8 +89,16 @@ impl TextEditor {
         Self::new_from_data(data).initialize(keyboard_actions)
     }
 
+    fn get_save_keys_mask() -> KeyMask {
+        if let Platform::MacOS = Platform::query() {
+            KeyMask::meta_plus('s')
+        } else {
+            KeyMask::control_plus('s')
+        }
+    }
+
     fn initialize(self, keyboard_actions:&mut keyboard::Actions) -> Self {
-        let save_keys   = KeyMask::control_plus('s');
+        let save_keys   = Self::get_save_keys_mask();
         let text_editor = Rc::downgrade(&self.rc);
         keyboard_actions.add_action_for_key_mask(save_keys,enclose!((text_editor) move || {
             if let Some(text_editor) = text_editor.upgrade() {

--- a/src/rust/lib/frp/src/io/keyboard.rs
+++ b/src/rust/lib/frp/src/io/keyboard.rs
@@ -31,6 +31,11 @@ pub use keyboard_types::Key;
 pub struct KeyMask(pub BitField256);
 
 impl KeyMask {
+    /// Creates Key::Meta + Key::Character.
+    pub fn meta_plus(character:char) -> Self {
+        Self::from_vec(vec![Key::Meta, Key::Character(character.to_string())])
+    }
+
     /// Creates Key::Control + Key::Character.
     pub fn control_plus(character:char) -> Self {
         Self::from_vec(vec![Key::Control, Key::Character(character.to_string())])


### PR DESCRIPTION
### Pull Request Description
This PR fixes an issue on MacOS which kept text field typing when using `command` modifier key.

### Important Notes
* Platform::query() was used to deal with OS intricacies.

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/master/doc/rust-style-guide.md), [Scala](https://github.com/luna/enso/blob/master/doc/scala-style-guide.md), [Java](https://github.com/luna/enso/blob/master/doc/java-style-guide.md) or [Haskell](https://github.com/luna/enso/blob/master/doc/haskell-style-guide.md) style guides as appropriate.
- [ ] All code has been tested where possible.
- [x] All code has been profiled where possible.

