### PR TITLE
Connect nodes starting from input ports.

### DIFF
--- a/build/run.js
+++ b/build/run.js
@@ -127,7 +127,7 @@ commands.build.rust = async function(argv) {
 
         console.log('Checking the resulting WASM size.')
         let stats = fss.statSync(paths.dist.wasm.mainOptGz)
-        let limit = 3.27
+        let limit = 3.29
         let size = Math.round(100 * stats.size / 1024 / 1024) / 100
         if (size > limit) {
             throw(`Output file size exceeds the limit (${size}MB > ${limit}MB).`)

--- a/src/rust/lib/graph-editor/src/component/cursor.rs
+++ b/src/rust/lib/graph-editor/src/component/cursor.rs
@@ -21,7 +21,7 @@ use ensogl::gui::component;
 
 const PADDING        : f32 = 2.0;
 const SIDES_PADDING  : f32 = PADDING * 2.0;
-const DEFAULT_RADIUS : f32 = 8.0;
+pub(crate) const DEFAULT_RADIUS : f32 = 8.0;
 const DEFAULT_COLOR  : color::Lcha = color::Lcha::new(1.0,0.0,0.0,0.2);
 const FADE_OUT_TIME  : f32 = 3000.0;
 

--- a/src/rust/lib/graph-editor/src/component/cursor.rs
+++ b/src/rust/lib/graph-editor/src/component/cursor.rs
@@ -21,7 +21,7 @@ use ensogl::gui::component;
 
 const PADDING        : f32 = 2.0;
 const SIDES_PADDING  : f32 = PADDING * 2.0;
-pub(crate) const DEFAULT_RADIUS : f32 = 8.0;
+pub const DEFAULT_RADIUS : f32 = 8.0;
 const DEFAULT_COLOR  : color::Lcha = color::Lcha::new(1.0,0.0,0.0,0.2);
 const FADE_OUT_TIME  : f32 = 3000.0;
 

--- a/src/rust/lib/graph-editor/src/component/cursor.rs
+++ b/src/rust/lib/graph-editor/src/component/cursor.rs
@@ -19,12 +19,12 @@ use ensogl::gui::component;
 // === Constants ===
 // =================
 
-const PADDING        : f32 = 2.0;
-const SIDES_PADDING  : f32 = PADDING * 2.0;
-/// Default radius of the mousse cursor symbol.
+/// Default radius of the mouse cursor symbol.
 pub const DEFAULT_RADIUS : f32 = 8.0;
-const DEFAULT_COLOR  : color::Lcha = color::Lcha::new(1.0,0.0,0.0,0.2);
-const FADE_OUT_TIME  : f32 = 3000.0;
+    const PADDING        : f32 = 2.0;
+    const SIDES_PADDING  : f32 = PADDING * 2.0;
+    const DEFAULT_COLOR  : color::Lcha = color::Lcha::new(1.0,0.0,0.0,0.2);
+    const FADE_OUT_TIME  : f32 = 3000.0;
 
 #[allow(non_snake_case)]
 fn DEFAULT_SIZE() -> Vector2<f32> { Vector2(16.0,16.0) }

--- a/src/rust/lib/graph-editor/src/component/cursor.rs
+++ b/src/rust/lib/graph-editor/src/component/cursor.rs
@@ -21,6 +21,7 @@ use ensogl::gui::component;
 
 const PADDING        : f32 = 2.0;
 const SIDES_PADDING  : f32 = PADDING * 2.0;
+/// Default radius of the mousse cursor symbol.
 pub const DEFAULT_RADIUS : f32 = 8.0;
 const DEFAULT_COLOR  : color::Lcha = color::Lcha::new(1.0,0.0,0.0,0.2);
 const FADE_OUT_TIME  : f32 = 3000.0;

--- a/src/rust/lib/graph-editor/src/component/edge.rs
+++ b/src/rust/lib/graph-editor/src/component/edge.rs
@@ -336,10 +336,6 @@ pub struct Frp {
     pub source_height             : frp::Source<f32>,
     pub target_position           : frp::Source<Vector2>,
     pub target_attached           : frp::Source<bool>,
-    pub source_width_no_redraw    : frp::Source<f32>,
-    pub source_height_no_redraw   : frp::Source<f32>,
-    pub target_position_no_redraw : frp::Source<Vector2>,
-    pub target_attached_no_redraw : frp::Source<bool>,
     pub redraw                    : frp::Source<()>,
 }
 
@@ -351,15 +347,9 @@ impl Frp {
             def source_height             = source();
             def target_position           = source();
             def target_attached           = source();
-            def source_width_no_redraw    = source();
-            def source_height_no_redraw   = source();
-            def target_position_no_redraw = source();
-            def target_attached_no_redraw = source();
             def redraw                    = source();
         }
-        Self {source_width,source_height,target_position,target_attached,redraw,
-              source_width_no_redraw,source_height_no_redraw,target_position_no_redraw,
-              target_attached_no_redraw}
+        Self {source_width,source_height,target_position,target_attached,redraw}
     }
 }
 
@@ -446,17 +436,11 @@ impl Edge {
         let source_height   = &self.source_height;
         let model           = &self.model;
         frp::extend! { network
-            eval input.target_position_no_redraw ((t) target_position.set(*t));
-            eval input.target_attached_no_redraw ((t) target_attached.set(*t));
-            eval input.source_width_no_redraw    ((t) source_width.set(*t));
-            eval input.source_height_no_redraw   ((t) source_height.set(*t));
             eval input.target_position           ((t) target_position.set(*t));
             eval input.target_attached           ((t) target_attached.set(*t));
             eval input.source_width              ((t) source_width.set(*t));
             eval input.source_height             ((t) source_height.set(*t));
-            on_change <- any_ (input.redraw, input.source_width, input.target_position,
-                               input.target_attached);
-            eval_ on_change (model.redraw());
+            eval_ input.redraw (model.redraw());
         }
         self
     }

--- a/src/rust/lib/graph-editor/src/component/edge.rs
+++ b/src/rust/lib/graph-editor/src/component/edge.rs
@@ -332,22 +332,34 @@ pub fn sort_hack_2(scene:&Scene) {
 #[derive(Clone,CloneRef,Debug)]
 #[allow(missing_docs)]
 pub struct Frp {
-    pub source_width    : frp::Source<f32>,
-    pub source_height   : frp::Source<f32>,
-    pub target_position : frp::Source<Vector2>,
-    pub target_attached : frp::Source<bool>,
+    pub source_width              : frp::Source<f32>,
+    pub source_height             : frp::Source<f32>,
+    pub target_position           : frp::Source<Vector2>,
+    pub target_attached           : frp::Source<bool>,
+    pub source_width_no_redraw    : frp::Source<f32>,
+    pub source_height_no_redraw   : frp::Source<f32>,
+    pub target_position_no_redraw : frp::Source<Vector2>,
+    pub target_attached_no_redraw : frp::Source<bool>,
+    pub redraw                    : frp::Source<()>,
 }
 
 impl Frp {
     /// Constructor.
     pub fn new(network:&frp::Network) -> Self {
         frp::extend! { network
-            def source_width    = source();
-            def source_height   = source();
-            def target_position = source();
-            def target_attached = source();
+            def source_width              = source();
+            def source_height             = source();
+            def target_position           = source();
+            def target_attached           = source();
+            def source_width_no_redraw    = source();
+            def source_height_no_redraw   = source();
+            def target_position_no_redraw = source();
+            def target_attached_no_redraw = source();
+            def redraw                    = source();
         }
-        Self {source_width,source_height,target_position,target_attached}
+        Self {source_width,source_height,target_position,target_attached,redraw,
+              source_width_no_redraw,source_height_no_redraw,target_position_no_redraw,
+              target_attached_no_redraw}
     }
 }
 
@@ -434,11 +446,16 @@ impl Edge {
         let source_height   = &self.source_height;
         let model           = &self.model;
         frp::extend! { network
-            eval input.target_position ((t) target_position.set(*t));
-            eval input.target_attached ((t) target_attached.set(*t));
-            eval input.source_width    ((t) source_width.set(*t));
-            eval input.source_height   ((t) source_height.set(*t));
-            on_change <- any_ (input.source_width, input.target_position, input.target_attached);
+            eval input.target_position_no_redraw ((t) target_position.set(*t));
+            eval input.target_attached_no_redraw ((t) target_attached.set(*t));
+            eval input.source_width_no_redraw    ((t) source_width.set(*t));
+            eval input.source_height_no_redraw   ((t) source_height.set(*t));
+            eval input.target_position           ((t) target_position.set(*t));
+            eval input.target_attached           ((t) target_attached.set(*t));
+            eval input.source_width              ((t) source_width.set(*t));
+            eval input.source_height             ((t) source_height.set(*t));
+            on_change <- any_ (input.redraw, input.source_width, input.target_position,
+                               input.target_attached);
             eval_ on_change (model.redraw());
         }
         self

--- a/src/rust/lib/graph-editor/src/component/node.rs
+++ b/src/rust/lib/graph-editor/src/component/node.rs
@@ -321,6 +321,10 @@ impl NodeModel {
         self.ports.width() + TEXT_OFF * 2.0
     }
 
+    pub fn height(&self) -> f32 {
+        NODE_HEIGHT
+    }
+
     fn set_expression(&self, expr:impl Into<Expression>) {
         let expr = expr.into();
         self.ports.set_expression(expr);

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -1843,9 +1843,9 @@ fn new_graph_editor(world:&World) -> GraphEditor {
     eval edge_refresh_cursor_pos_no_hover ([edges,model](position) {
         edges.detached_source.for_each(|edge_id| {
             if let Some(edge) = edges.get_cloned_ref(edge_id) {
-                edge.view.frp.source_width.emit(cursor::DEFAULT_RADIUS);
-                edge.view.frp.source_height.emit(cursor::DEFAULT_RADIUS);
-                edge.view.frp.target_position.emit(-position.xy());
+                edge.view.frp.source_width_no_redraw.emit(cursor::DEFAULT_RADIUS);
+                edge.view.frp.source_height_no_redraw.emit(cursor::DEFAULT_RADIUS);
+                edge.view.frp.target_position_no_redraw.emit(-position.xy());
                 edge.mod_position(|p| {
                     p.x = position.x;
                     p.y = position.y;

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -420,6 +420,7 @@ pub struct FrpInputs {
     #[shrinkwrap(main_field)]
     commands                         : Commands,
     pub set_detached_edge_targets    : frp::Source<EdgeTarget>,
+    pub set_detached_edge_sources    : frp::Source<EdgeTarget>,
     pub set_edge_source              : frp::Source<(EdgeId,EdgeTarget)>,
     pub set_edge_target              : frp::Source<(EdgeId,EdgeTarget)>,
     pub unset_edge_source            : frp::Source<EdgeId>,
@@ -427,6 +428,7 @@ pub struct FrpInputs {
     pub connect_nodes                : frp::Source<(EdgeTarget,EdgeTarget)>,
     pub deselect_all_nodes           : frp::Source,
     pub press_node_input             : frp::Source<EdgeTarget>,
+    pub press_node_output            : frp::Source<EdgeTarget>,
     pub remove_all_node_edges        : frp::Source<NodeId>,
     pub remove_all_node_input_edges  : frp::Source<NodeId>,
     pub remove_all_node_output_edges : frp::Source<NodeId>,
@@ -441,14 +443,20 @@ pub struct FrpInputs {
     pub set_visualization_data       : frp::Source<(NodeId,visualization::Data)>,
 
     hover_node_input           : frp::Source<Option<EdgeTarget>>,
+    hover_node_output          : frp::Source<Option<EdgeTarget>>,
     some_edge_targets_detached : frp::Source,
+    some_edge_sources_detached : frp::Source,
     all_edge_targets_attached  : frp::Source,
+    all_edge_sources_attached  : frp::Source,
+    all_edges_attached         : frp::Source,
+
 }
 
 impl FrpInputs {
     pub fn new(network:&frp::Network) -> Self {
         frp::extend! { network
             def set_detached_edge_targets    = source();
+            def set_detached_edge_sources    = source();
             def set_edge_source              = source();
             def set_edge_target              = source();
             def unset_edge_source            = source();
@@ -456,6 +464,7 @@ impl FrpInputs {
             def connect_nodes                = source();
             def deselect_all_nodes           = source();
             def press_node_input             = source();
+            def press_node_output            = source();
             def remove_all_node_edges        = source();
             def remove_all_node_input_edges  = source();
             def remove_all_node_output_edges = source();
@@ -470,8 +479,12 @@ impl FrpInputs {
             def register_visualization = source();
 
             def hover_node_input           = source();
+            def hover_node_output          = source();
             def some_edge_targets_detached = source();
+            def some_edge_sources_detached = source();
             def all_edge_targets_attached  = source();
+            def all_edge_sources_attached  = source();
+            def all_edges_attached  = source();
         }
         let commands = Commands::new(&network);
         Self {commands,remove_edge,press_node_input,remove_all_node_edges
@@ -480,8 +493,9 @@ impl FrpInputs {
              ,unset_edge_source,unset_edge_target
              ,set_node_position,select_node,remove_node,set_node_expression
              ,connect_nodes,deselect_all_nodes,cycle_visualization,set_visualization
-             ,register_visualization,some_edge_targets_detached,all_edge_targets_attached
-             ,hover_node_input
+             ,register_visualization,some_edge_targets_detached,some_edge_sources_detached
+             ,all_edge_targets_attached,hover_node_input,all_edge_sources_attached
+             ,hover_node_output,press_node_output,set_detached_edge_sources,all_edges_attached
              }
     }
 }
@@ -570,7 +584,10 @@ generate_frp_outputs! {
     edge_target_unset : EdgeId,
 
     some_edge_targets_detached : (),
+    some_edge_sources_detached : (),
     all_edge_targets_attached  : (),
+    all_edge_sources_attached  : (),
+    all_edges_attached         : (),
 
     connection_added    : EdgeId,
     connection_removed  : EdgeId,
@@ -936,6 +953,7 @@ impl GraphEditorModelWithNetwork {
     ( &self
     , cursor_style : &frp::Source<cursor::Style>
     , output_press : &frp::Source<NodeId>
+    , input_press  : &frp::Source<(NodeId,span_tree::Crumbs)>
     ) -> NodeId {
         let view = component::Node::new(&self.scene);
         let node = Node::new(view);
@@ -950,13 +968,22 @@ impl GraphEditorModelWithNetwork {
             eval  node.ports.frp.cursor_style ((style) cursor_style.emit(style));
             eval_ node.frp.output_ports.mouse_down (output_press.emit(node_id));
             eval  node.ports.frp.press ((crumbs)
-                model.frp.press_node_input.emit(EdgeTarget::new(node_id,crumbs.clone()))
+                input_press.emit((node_id,crumbs.clone()));
             );
 
             eval node.ports.frp.hover ([model](crumbs) {
                 let target = crumbs.as_ref().map(|c| EdgeTarget::new(node_id,c.clone()));
                 model.frp.hover_node_input.emit(target);
             });
+
+             eval node.frp.output_ports.mouse_over ([model](_) {
+                let target = EdgeTarget::new(node_id,default());
+                model.frp.hover_node_output.emit(Some(target));
+             });
+
+             eval node.frp.output_ports.mouse_out ([model](_) {
+                model.frp.hover_node_output.emit(None);
+             });
         }
 
 //        self.visualizations.push(node.visualization().clone_ref());
@@ -1004,7 +1031,7 @@ impl GraphEditorModel {
         Self {logger,display_object,scene,cursor,nodes,edges,touch_state,frp}//visualizations }
     }
 
-    fn new_edge(&self) -> EdgeId {
+    fn new_edge_from_output(&self) -> EdgeId {
         let edge    = Edge::new(component::Edge::new(&self.scene));
         let edge_id = edge.id();
         self.add_child(&edge);
@@ -1014,6 +1041,22 @@ impl GraphEditorModel {
         self.edges.detached_target.insert(edge_id);
         if first_detached {
             self.frp.some_edge_targets_detached.emit(());
+        }
+
+        edge_id
+    }
+
+    fn new_edge_from_input(&self) -> EdgeId {
+        let edge    = Edge::new(component::Edge::new(&self.scene));
+
+        let edge_id = edge.id();
+        self.add_child(&edge);
+        self.edges.insert(edge.clone_ref());
+
+        let first_detached = self.edges.detached_source.is_empty();
+        self.edges.detached_source.insert(edge_id);
+        if first_detached {
+            self.frp.some_edge_sources_detached.emit(());
         }
 
         edge_id
@@ -1184,10 +1227,28 @@ impl GraphEditorModel {
 
     fn take_edges_with_detached_targets(&self) -> HashSet<EdgeId> {
         let edges = self.edges.detached_target.mem_take();
-        if !edges.is_empty() {
+        self.check_edge_attachment_status_and_emit_events();
+        edges
+    }
+
+    fn take_edges_with_detached_sources(&self) -> HashSet<EdgeId> {
+        let edges = self.edges.detached_source.mem_take();
+        self.check_edge_attachment_status_and_emit_events();
+        edges
+    }
+
+    fn check_edge_attachment_status_and_emit_events(&self) {
+        let has_detached_sources = self.edges.detached_source.is_empty();
+        let has_detached_targets = self.edges.detached_target.is_empty();
+        if !has_detached_targets {
             self.frp.all_edge_targets_attached.emit(());
         }
-        edges
+        if !has_detached_sources {
+            self.frp.all_edge_sources_attached.emit(());
+        }
+        if !has_detached_targets &&  !has_detached_sources {
+            self.frp.all_edges_attached.emit(());
+        }
     }
 
     fn overlapping_edges(&self, target:&EdgeTarget) -> Vec<EdgeId> {
@@ -1472,13 +1533,11 @@ fn new_graph_editor(world:&World) -> GraphEditor {
     frp::extend! { network
 
     let style = cursor::Style::new_color_no_animation(color::Lcha::new(0.6,0.5,0.76,1.0)).press();
-    cursor_style_on_edge_drag      <- outputs.some_edge_targets_detached.constant(style);
-    cursor_style_on_edge_drag_stop <- outputs.all_edge_targets_attached.constant(default());
-    cursor_style_edge_drag         <- any (cursor_style_on_edge_drag,cursor_style_on_edge_drag_stop);
-
-
-
-
+    cursor_style_source_drag       <- outputs.some_edge_sources_detached.constant(style.clone());
+    cursor_style_target_drag       <- outputs.some_edge_targets_detached.constant(style.clone());
+    cursor_style_on_edge_drag_stop <- outputs.all_edges_attached.constant(default());
+    cursor_style_edge_drag         <- any (cursor_style_source_drag,cursor_style_target_drag,
+                                           cursor_style_on_edge_drag_stop);
 
     }
 
@@ -1564,22 +1623,40 @@ fn new_graph_editor(world:&World) -> GraphEditor {
 
     node_cursor_style <- source::<cursor::Style>();
 
-
+    let node_input_touch  = TouchNetwork::<(NodeId,span_tree::Crumbs)>::new(&network,&mouse);
     let node_output_touch = TouchNetwork::<NodeId>::new(&network,&mouse);
-    on_connect_drag_mode   <- node_output_touch.down.constant(true);
-    on_connect_follow_mode <- node_output_touch.selected.constant(false);
+
+    on_output_connect_drag_mode   <- node_output_touch.down.constant(true);
+    on_output_connect_follow_mode <- node_output_touch.selected.constant(false);
+    on_input_connect_drag_mode    <- node_input_touch.down.constant(true);
+    on_input_connect_follow_mode  <- node_input_touch.selected.constant(false);
+
+    eval node_input_touch.down (((node_id,crumbs)) {
+        model.frp.press_node_input.emit(EdgeTarget::new(node_id,crumbs.clone()))
+    });
+
+    eval node_output_touch.down ([model](node_id) {
+        model.frp.press_node_output.emit(EdgeTarget::new(node_id,default()));
+    });
+
+    on_connect_drag_mode   <- any(on_output_connect_drag_mode,on_input_connect_drag_mode);
+    on_connect_follow_mode <- any(on_output_connect_follow_mode,on_input_connect_follow_mode);
     connect_drag_mode      <- any (on_connect_drag_mode,on_connect_follow_mode);
 
-    new_edge <- node_output_touch.down.map(f_!(model.new_edge()));
+    new_output_edge <- node_output_touch.down.map(f_!(model.new_edge_from_output()));
+    new_input_edge  <- node_input_touch.down.map(f_!(model.new_edge_from_input()));
 
-    outputs.edge_added <+ new_edge;
-    new_edge_source <- new_edge.map2(&node_output_touch.down, move |id,node_id| (*id,EdgeTarget::new(node_id,default())));
+    outputs.edge_added <+ new_output_edge;
+    new_edge_source <- new_output_edge.map2(&node_output_touch.down, move |id,node_id| (*id,EdgeTarget::new(node_id,default())));
     outputs.edge_source_set <+ new_edge_source;
 
+    outputs.edge_added <+ new_input_edge;
+    new_edge_target <- new_input_edge.map2(&node_input_touch.down, move |id,(node_id,crumbs)| (*id,EdgeTarget::new(node_id,crumbs.clone())));
+    outputs.edge_target_set <+ new_edge_target;
 
     let add_node_at_cursor = inputs.add_node_at_cursor.clone_ref();
     add_node           <- any (inputs.add_node, add_node_at_cursor);
-    new_node           <- add_node.map(f_!([model,node_cursor_style] model.new_node(&node_cursor_style,&node_output_touch.down)));
+    new_node           <- add_node.map(f_!([model,node_cursor_style] model.new_node(&node_cursor_style,&node_output_touch.down,&node_input_touch.down)));
     outputs.node_added <+ new_node;
 
     node_with_position <- add_node_at_cursor.map3(&new_node,&mouse.position,|_,id,pos| (*id,*pos));
@@ -1599,27 +1676,35 @@ fn new_graph_editor(world:&World) -> GraphEditor {
     outputs.edge_target_set <+ inputs.set_edge_target;
 
     let endpoints            = inputs.connect_nodes.clone_ref();
-    edge                    <- endpoints . map(f_!(model.new_edge()));
+    edge                    <- endpoints . map(f_!(model.new_edge_from_output()));
     new_edge_source         <- endpoints . _0() . map2(&edge, |t,id| (*id,t.clone()));
     new_edge_target         <- endpoints . _1() . map2(&edge, |t,id| (*id,t.clone()));
     outputs.edge_added      <+ edge;
     outputs.edge_source_set <+ new_edge_source;
     outputs.edge_target_set <+ new_edge_target;
 
+    port_input_mouse_up  <- inputs.hover_node_input.sample(&mouse.up).unwrap();
+    port_output_mouse_up <- inputs.hover_node_output.sample(&mouse.up).unwrap();
 
-    port_mouse_up <- inputs.hover_node_input.sample(&mouse.up).unwrap();
+    attach_all_edge_inputs  <- any (port_input_mouse_up, inputs.press_node_input, inputs.set_detached_edge_targets);
+    attach_all_edge_outputs <- any (port_output_mouse_up, inputs.press_node_output, inputs.set_detached_edge_sources);
 
-    attach_all_edges        <- any (port_mouse_up, inputs.press_node_input, inputs.set_detached_edge_targets);
-    detached_edge           <= attach_all_edges.map(f_!(model.take_edges_with_detached_targets()));
-    new_edge_target         <- detached_edge.map2(&attach_all_edges, |id,t| (*id,t.clone()));
+    detached_edges_without_targets <= attach_all_edge_inputs.map(f_!(model.take_edges_with_detached_targets()));
+    detached_edges_without_sources <= attach_all_edge_outputs.map(f_!(model.take_edges_with_detached_sources()));
+
+    new_edge_target <- detached_edges_without_targets.map2(&attach_all_edge_inputs, |id,t| (*id,t.clone()));
     outputs.edge_target_set <+ new_edge_target;
+    new_edge_source <- detached_edges_without_sources.map2(&attach_all_edge_outputs, |id,t| (*id,t.clone()));
+    outputs.edge_source_set <+ new_edge_source;
 
     overlapping_edges       <= outputs.edge_target_set._1().map(f!((t) model.overlapping_edges(t)));
     outputs.edge_removed    <+ overlapping_edges;
 
     drop_on_bg_up  <- background_up.gate(&connect_drag_mode);
     drop_edges     <- any (drop_on_bg_up,touch.background.down);
-    edge_to_drop   <= drop_edges.map(f_!(model.take_edges_with_detached_targets()));
+    edge_to_drop_without_targets <= drop_edges.map(f_!(model.take_edges_with_detached_targets()));
+    edge_to_drop_without_sources <= drop_edges.map(f_!(model.take_edges_with_detached_sources()));
+    edge_to_drop <- any(edge_to_drop_without_targets,edge_to_drop_without_sources);
     eval edge_to_drop ((id) model.remove_edge(id));
 
     }
@@ -1738,17 +1823,55 @@ fn new_graph_editor(world:&World) -> GraphEditor {
 
 
     // === Move Edges ===
-
-    cursor_pos_on_detach    <- cursor.frp.position.sample(&inputs.some_edge_targets_detached);
+    detached_edge           <- any(&inputs.some_edge_targets_detached,&inputs.some_edge_sources_detached);
+    cursor_pos_on_detach    <- cursor.frp.position.sample(&detached_edge);
     edge_refresh_cursor_pos <- any (cursor_pos_on_detach,cursor.frp.position);
-    eval edge_refresh_cursor_pos ([edges](position) {
+
+    is_hovering_output <- inputs.hover_node_output.map(|target| target.is_some());
+    hover_node         <- inputs.hover_node_output.unwrap();
+
+    edge_refresh_cursor_pos_on_node_hover <- edge_refresh_cursor_pos.gate(&is_hovering_output);
+    edge_refresh_on_node_hover            <- all(edge_refresh_cursor_pos,hover_node);
+    edge_refresh_cursor_pos_no_hover      <- edge_refresh_cursor_pos.gate_not(&is_hovering_output);
+
+    eval edge_refresh_cursor_pos_no_hover ([edges,model](position) {
         edges.detached_target.for_each(|id| {
             if let Some(edge) = edges.get_cloned_ref(id) {
                 edge.view.frp.target_position.emit(position.xy())
             }
-        })
+        });
+        edges.detached_source.for_each(|edge_id| {
+            if let Some(edge) = edges.get_cloned_ref(edge_id) {
+                edge.view.frp.source_width.emit(cursor::DEFAULT_RADIUS);
+                edge.view.frp.target_position.emit(-position.xy());
+                edge.mod_position(|p| {
+                    p.x = position.x;
+                    p.y = position.y;
+                });
+                model.refresh_edge_position(*edge_id);
+            }
+        });
     });
 
+    // Snap t
+    eval edge_refresh_on_node_hover ([nodes,edges,model]((position,target)) {
+        edges.detached_source.for_each(|edge_id| {
+            if let Some(node) = nodes.get_cloned_ref(&target.node_id) {
+                if let Some(edge) = edges.get_cloned_ref(edge_id) {
+                    let node_width = node.view.model.width();
+                    let node_pos = node.position();
+
+                    edge.view.frp.source_width.emit(node_width);
+                    edge.view.frp.target_position.emit(-node_pos.xy());
+                    edge.mod_position(|p| {
+                        p.x = node_pos.x + node_width / 2.0;
+                        p.y = node_pos.y + node::NODE_HEIGHT/2.0;
+                    });
+                    model.refresh_edge_position(*edge_id);
+                }
+            }
+        });
+    });
 
 
     // ====================
@@ -1912,7 +2035,9 @@ fn new_graph_editor(world:&World) -> GraphEditor {
     // === OUTPUTS REBIND ===
 
     outputs.some_edge_targets_detached <+ inputs.some_edge_targets_detached;
+    outputs.some_edge_sources_detached <+ inputs.some_edge_sources_detached;
     outputs.all_edge_targets_attached  <+ inputs.all_edge_targets_attached;
+     outputs.all_edges_attached        <+ inputs.all_edges_attached;
 
     eval outputs.edge_source_set        (((id,tgt)) model.set_edge_source(*id,tgt));
     eval outputs.edge_target_set        (((id,tgt)) model.set_edge_target(*id,tgt));

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -1534,7 +1534,7 @@ fn new_graph_editor(world:&World) -> GraphEditor {
 
     let style = cursor::Style::new_color_no_animation(color::Lcha::new(0.6,0.5,0.76,1.0)).press();
     cursor_style_source_drag       <- outputs.some_edge_sources_detached.constant(style.clone());
-    cursor_style_target_drag       <- outputs.some_edge_targets_detached.constant(style.clone());
+    cursor_style_target_drag       <- outputs.some_edge_targets_detached.constant(style);
     cursor_style_on_edge_drag_stop <- outputs.all_edges_attached.constant(default());
     cursor_style_edge_drag         <- any (cursor_style_source_drag,cursor_style_target_drag,
                                            cursor_style_on_edge_drag_stop);

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -982,9 +982,7 @@ impl GraphEditorModelWithNetwork {
                 model.frp.hover_node_output.emit(Some(target));
              });
 
-             eval_ node.frp.output_ports.mouse_out ({Simpligy
-                model.frp.hover_node_output.emit(None);
-             });
+             eval_ node.frp.output_ports.mouse_out ( model.frp.hover_node_output.emit(None));
         }
 
 //        self.visualizations.push(node.visualization().clone_ref());
@@ -1634,11 +1632,9 @@ fn new_graph_editor(world:&World) -> GraphEditor {
     on_input_connect_drag_mode    <- node_input_touch.down.constant(true);
     on_input_connect_follow_mode  <- node_input_touch.selected.constant(false);
 
-    eval node_input_touch.down ((target) {
-        model.frp.press_node_input.emit(target)
-    });
+    eval node_input_touch.down ((target) model.frp.press_node_input.emit(target));
 
-    eval node_output_touch.down ([model](node_id) {
+    eval node_output_touch.down ((node_id) {
         model.frp.press_node_output.emit(EdgeTarget::new(node_id,default()));
     });
 

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -1176,7 +1176,7 @@ impl GraphEditorModel {
             node.frp.set_expression.emit(expr);
         }
         for edge_id in self.node_out_edges(node_id) {
-            self.refresh_edge_source_width(edge_id);
+            self.refresh_edge_source_size(edge_id);
         }
     }
 
@@ -1201,7 +1201,7 @@ impl GraphEditorModel {
                 edge.set_source(target);
                 // FIXME: both lines require edge to refresh. Let's make it more efficient.
                 self.refresh_edge_position(edge_id);
-                self.refresh_edge_source_width(edge_id);
+                self.refresh_edge_source_size(edge_id);
             }
         }
     }
@@ -1310,11 +1310,12 @@ impl GraphEditorModel {
         self.refresh_edge_target_position(edge_id);
     }
 
-    pub fn refresh_edge_source_width(&self, edge_id:EdgeId) {
+    pub fn refresh_edge_source_size(&self, edge_id:EdgeId) {
         if let Some(edge) = self.edges.get_cloned_ref(&edge_id) {
             if let Some(edge_source) = edge.source() {
                 if let Some(node) = self.nodes.get_cloned_ref(&edge_source.node_id) {
                     edge.view.frp.source_width.emit(node.width());
+                    edge.view.frp.source_height.emit(node.height());
                 }
             }
         };
@@ -1845,6 +1846,7 @@ fn new_graph_editor(world:&World) -> GraphEditor {
         edges.detached_source.for_each(|edge_id| {
             if let Some(edge) = edges.get_cloned_ref(edge_id) {
                 edge.view.frp.source_width.emit(cursor::DEFAULT_RADIUS);
+                edge.view.frp.source_height.emit(cursor::DEFAULT_RADIUS);
                 edge.view.frp.target_position.emit(-position.xy());
                 edge.mod_position(|p| {
                     p.x = position.x;
@@ -1859,10 +1861,12 @@ fn new_graph_editor(world:&World) -> GraphEditor {
         edges.detached_source.for_each(|edge_id| {
             if let Some(node) = nodes.get_cloned_ref(&target.node_id) {
                 if let Some(edge) = edges.get_cloned_ref(edge_id) {
-                    let node_width = node.view.model.width();
-                    let node_pos = node.position();
+                    let node_width  = node.view.model.width();
+                    let node_height = node.view.model.height();
+                    let node_pos    = node.position();
 
                     edge.view.frp.source_width.emit(node_width);
+                    edge.view.frp.source_height.emit(node_height);
                     edge.view.frp.target_position.emit(-node_pos.xy());
                     edge.mod_position(|p| {
                         p.x = node_pos.x + node_width / 2.0;

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -1220,6 +1220,7 @@ impl GraphEditorModel {
                 }
 
                 edge.view.frp.target_attached.emit(true);
+                edge.view.frp.redraw.emit(());
                 self.refresh_edge_position(edge_id);
             };
         }
@@ -1316,6 +1317,7 @@ impl GraphEditorModel {
                 if let Some(node) = self.nodes.get_cloned_ref(&edge_source.node_id) {
                     edge.view.frp.source_width.emit(node.width());
                     edge.view.frp.source_height.emit(node.height());
+                    edge.view.frp.redraw.emit(());
                 }
             }
         };
@@ -1341,6 +1343,7 @@ impl GraphEditorModel {
                     let offset = node.ports.get_port_offset(&edge_target.port).unwrap_or_default();
                     let pos = node.position().xy() + offset;
                     edge.view.frp.target_position.emit(pos);
+                    edge.view.frp.redraw.emit(());
                 }
             }
         };
@@ -1835,7 +1838,8 @@ fn new_graph_editor(world:&World) -> GraphEditor {
     eval edge_refresh_cursor_pos ((position) {
         edges.detached_target.for_each(|id| {
             if let Some(edge) = edges.get_cloned_ref(id) {
-                edge.view.frp.target_position.emit(position.xy())
+                edge.view.frp.target_position.emit(position.xy());
+                edge.view.frp.redraw.emit(());
             }
         });
     });
@@ -1843,9 +1847,10 @@ fn new_graph_editor(world:&World) -> GraphEditor {
     eval edge_refresh_cursor_pos_no_hover ([edges,model](position) {
         edges.detached_source.for_each(|edge_id| {
             if let Some(edge) = edges.get_cloned_ref(edge_id) {
-                edge.view.frp.source_width_no_redraw.emit(cursor::DEFAULT_RADIUS);
-                edge.view.frp.source_height_no_redraw.emit(cursor::DEFAULT_RADIUS);
-                edge.view.frp.target_position_no_redraw.emit(-position.xy());
+                edge.view.frp.source_width.emit(cursor::DEFAULT_RADIUS);
+                edge.view.frp.source_height.emit(cursor::DEFAULT_RADIUS);
+                edge.view.frp.target_position.emit(-position.xy());
+                edge.view.frp.redraw.emit(());
                 edge.mod_position(|p| {
                     p.x = position.x;
                     p.y = position.y;
@@ -1866,6 +1871,7 @@ fn new_graph_editor(world:&World) -> GraphEditor {
                     edge.view.frp.source_width.emit(node_width);
                     edge.view.frp.source_height.emit(node_height);
                     edge.view.frp.target_position.emit(-node_pos.xy());
+                    edge.view.frp.redraw.emit(());
                     edge.mod_position(|p| {
                         p.x = node_pos.x + node_width / 2.0;
                         p.y = node_pos.y + node::NODE_HEIGHT/2.0;

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -1032,11 +1032,16 @@ impl GraphEditorModel {
         Self {logger,display_object,scene,cursor,nodes,edges,touch_state,frp}//visualizations }
     }
 
-    fn new_edge_from_output(&self) -> EdgeId {
+    fn create_edge(&self) -> EdgeId {
         let edge    = Edge::new(component::Edge::new(&self.scene));
         let edge_id = edge.id();
         self.add_child(&edge);
         self.edges.insert(edge.clone_ref());
+        edge_id
+    }
+
+    fn new_edge_from_output(&self) -> EdgeId {
+        let edge_id = self.create_edge();
 
         let first_detached = self.edges.detached_target.is_empty();
         self.edges.detached_target.insert(edge_id);
@@ -1048,11 +1053,7 @@ impl GraphEditorModel {
     }
 
     fn new_edge_from_input(&self) -> EdgeId {
-        let edge    = Edge::new(component::Edge::new(&self.scene));
-
-        let edge_id = edge.id();
-        self.add_child(&edge);
-        self.edges.insert(edge.clone_ref());
+        let edge_id = self.create_edge();
 
         let first_detached = self.edges.detached_source.is_empty();
         self.edges.detached_source.insert(edge_id);

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -1248,7 +1248,7 @@ impl GraphEditorModel {
         if no_detached_sources {
             self.frp.all_edge_sources_attached.emit(());
         }
-        if no_detached_targets &&  no_detached_sources {
+        if no_detached_targets && no_detached_sources {
             self.frp.all_edges_attached.emit(());
         }
     }

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -1238,15 +1238,15 @@ impl GraphEditorModel {
     }
 
     fn check_edge_attachment_status_and_emit_events(&self) {
-        let has_detached_sources = self.edges.detached_source.is_empty();
-        let has_detached_targets = self.edges.detached_target.is_empty();
-        if !has_detached_targets {
+        let no_detached_sources = self.edges.detached_source.is_empty();
+        let no_detached_targets = self.edges.detached_target.is_empty();
+        if no_detached_targets {
             self.frp.all_edge_targets_attached.emit(());
         }
-        if !has_detached_sources {
+        if no_detached_sources {
             self.frp.all_edge_sources_attached.emit(());
         }
-        if !has_detached_targets &&  !has_detached_sources {
+        if no_detached_targets &&  no_detached_sources {
             self.frp.all_edges_attached.emit(());
         }
     }

--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -977,12 +977,12 @@ impl GraphEditorModelWithNetwork {
                 model.frp.hover_node_input.emit(target);
             });
 
-             eval node.frp.output_ports.mouse_over ([model](_) {
+             eval_ node.frp.output_ports.mouse_over ([model] {
                 let target = EdgeTarget::new(node_id,default());
                 model.frp.hover_node_output.emit(Some(target));
              });
 
-             eval node.frp.output_ports.mouse_out ([model](_) {
+             eval_ node.frp.output_ports.mouse_out ({Simpligy
                 model.frp.hover_node_output.emit(None);
              });
         }


### PR DESCRIPTION
### Pull Request Description
Adds the ability to start connections from input ports.

### Important Notes
Known issues:
* It is possible to start multiple connections from input and output ports. This will be addressed with #592
* On start dragging from an input port, the edge shape is not in the most aesthetically pleasing shape. (the cursor tries to select the port and the edge loops back)

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

