### PR TITLE
Change visualization toggle shortcut to Ctrl+Space

### DIFF
--- a/src/rust/lib/graph-editor/src/lib.rs
+++ b/src/rust/lib/graph-editor/src/lib.rs
@@ -1406,9 +1406,9 @@ impl application::shortcut::DefaultShortcutProvider for GraphEditor {
         use keyboard::Key;
         vec! [ Self::self_shortcut(shortcut::Action::press        (&[Key::Character("n".into())])               , "add_node_at_cursor")
              , Self::self_shortcut(shortcut::Action::press        (&[Key::Backspace])                           , "remove_selected_nodes")
-             , Self::self_shortcut(shortcut::Action::press        (&[Key::Character(" ".into())])               , "press_visualization_visibility")
-             , Self::self_shortcut(shortcut::Action::double_press (&[Key::Character(" ".into())])               , "double_press_visualization_visibility")
-             , Self::self_shortcut(shortcut::Action::release      (&[Key::Character(" ".into())])               , "release_visualization_visibility")
+             , Self::self_shortcut(shortcut::Action::press        (&[Key::Control,Key::Character(" ".into())])  , "press_visualization_visibility")
+             , Self::self_shortcut(shortcut::Action::double_press (&[Key::Control,Key::Character(" ".into())])  , "double_press_visualization_visibility")
+             , Self::self_shortcut(shortcut::Action::release      (&[Key::Control,Key::Character(" ".into())])  , "release_visualization_visibility")
              , Self::self_shortcut(shortcut::Action::press        (&[Key::Meta])                                , "toggle_node_multi_select")
              , Self::self_shortcut(shortcut::Action::release      (&[Key::Meta])                                , "toggle_node_multi_select")
              , Self::self_shortcut(shortcut::Action::press        (&[Key::Control])                             , "toggle_node_multi_select")


### PR DESCRIPTION
### Pull Request Description
As confirmed with @wdanilo previous change Ctrl-Space => Space was not intentional.

We want this shortcut to use Control, because otherwise text editor accepts space as text input.

### Important Notes
<!--
- Mention important elements of the design.
- Mention any notable changes to APIs.
-->

### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [ ] All code has been profiled where possible.

