### PR TITLE
Enable computation of SDF bounds for `grow` modifier.

### DIFF
--- a/src/rust/ensogl/src/display/shape/primitive/glsl/shape.glsl
+++ b/src/rust/ensogl/src/display/shape/primitive/glsl/shape.glsl
@@ -52,6 +52,13 @@ BoundingBox difference (BoundingBox a, BoundingBox b) {
     return a;
 }
 
+BoundingBox grow (BoundingBox a, float value) {
+    float min_x = a.min_x-value;
+    float max_x = a.max_x+value;
+    float min_y = a.min_y-value;
+    float max_y = a.max_y+value;
+    return  BoundingBox(min_x,max_x,min_y,max_y);
+}
 
 
 // ===========
@@ -140,7 +147,7 @@ BoundSdf pixel_snap (BoundSdf a) {
 
 BoundSdf grow (BoundSdf a, float size) {
     a.distance = a.distance - size;
-    // a.bounds   = grow(a.bounds,size);
+    a.bounds   = grow(a.bounds,size);
     return a;
 }
 

--- a/src/rust/ensogl/src/display/shape/primitive/glsl/shape.glsl
+++ b/src/rust/ensogl/src/display/shape/primitive/glsl/shape.glsl
@@ -57,7 +57,7 @@ BoundingBox grow (BoundingBox a, float value) {
     float max_x = a.max_x+value;
     float min_y = a.min_y-value;
     float max_y = a.max_y+value;
-    return  BoundingBox(min_x,max_x,min_y,max_y);
+    return BoundingBox(min_x,max_x,min_y,max_y);
 }
 
 


### PR DESCRIPTION
### Pull Request Description
Adds the adjustment of the bounds for the SDF `grow` modifier.


### Checklist
Please include the following checklist in your PR:

- [x] The documentation has been updated if necessary.
- [x] All code conforms to the [Rust](https://github.com/luna/enso/blob/main/docs/style-guide/rust.md).
- [x] All code has been tested where possible.
- [x] All code has been profiled where possible.

